### PR TITLE
(WIP, Do Not Merge) Bug 1425075 - config categories for each list

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -90,7 +90,10 @@ def get_output_and_log_files(config, section):
 
 
 def load_json_from_url(config, section, key):
-    url = config.get(section, key)
+    try:
+        url = config.get(section, key)
+    except ConfigParser.NoOptionError:
+        url = config.get("main", "default_disconnect_url")
     try:
         loaded_json = json.loads(urllib2.urlopen(url).read())
     except:

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -55,7 +55,10 @@ DNT_SECTIONS = (
     "tracking-protection-basew3c",
     "tracking-protection-content",
     "tracking-protection-contenteff",
-    "tracking-protection-contentw3c"
+    "tracking-protection-contentw3c",
+    "tracking-protection-ads",
+    "tracking-protection-analytics",
+    "tracking-protection-social",
 )
 DNT_CONTENT_SECTIONS = (
     "tracking-protection-content",

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -1,5 +1,6 @@
 # Copy to shavar_list_creation.ini to enable.
 [main]
+default_disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 # Whether or not to upload to s3. Requires s3_bucket and s3_key not to be empty.
 s3_upload=false
 # The s3 bucket to which to upload the output digest256 list, e.g., mmc-shavar
@@ -7,7 +8,6 @@ s3_bucket=mmc-shavar
 
 [tracking-protection]
 # The location of the Disconnect list
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 # The location of the allowlist
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
@@ -17,60 +17,50 @@ output=mozpub-track-digest256
 
 # DNT="", all categories except content category
 [tracking-protection-base]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=base-track-digest256
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=baseeff-track-digest256
 
 # DNT="W3C", all categories except content category
 [tracking-protection-basew3c]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=basew3c-track-digest256
 
 # DNT="", content category
 [tracking-protection-content]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Content
 output=content-track-digest256
 
 # DNT="", ads category
 [tracking-protection-ads]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Advertising
 output=content-track-digest256
 
 # DNT="", analytics category
 [tracking-protection-analytics]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Analytics
 output=content-track-digest256
 
 # DNT="", social category
 [tracking-protection-social]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Social
 output=content-track-digest256
 
 # DNT="EFF", content category
 [tracking-protection-contenteff]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Content
 output=contenteff-track-digest256
 
 # DNT="W3C", content category
 [tracking-protection-contentw3c]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Content
 output=contentw3c-track-digest256
 
 [tracking-protection-testing]
-disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 output=moztestpub-track-digest256

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -8,6 +8,7 @@ s3_bucket=mmc-shavar
 [tracking-protection]
 # The location of the Disconnect list
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
 # The location of the allowlist
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 # The filename of the generated data file.  This will be used as the S3 key
@@ -17,35 +18,42 @@ output=mozpub-track-digest256
 # DNT="", all categories except content category
 [tracking-protection-base]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=base-track-digest256
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=baseeff-track-digest256
 
 # DNT="W3C", all categories except content category
 [tracking-protection-basew3c]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=basew3c-track-digest256
 
 # DNT="", content category
 [tracking-protection-content]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Content
 output=content-track-digest256
 
 # DNT="EFF", content category
 [tracking-protection-contenteff]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Content
 output=contenteff-track-digest256
 
 # DNT="W3C", content category
 [tracking-protection-contentw3c]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Content
 output=contentw3c-track-digest256
 
 [tracking-protection-testing]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 output=moztestpub-track-digest256
 

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -39,6 +39,24 @@ disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-li
 disconnect_categories=Content
 output=content-track-digest256
 
+# DNT="", ads category
+[tracking-protection-ads]
+disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Advertising
+output=content-track-digest256
+
+# DNT="", analytics category
+[tracking-protection-analytics]
+disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Analytics
+output=content-track-digest256
+
+# DNT="", social category
+[tracking-protection-social]
+disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
+disconnect_categories=Social
+output=content-track-digest256
+
 # DNT="EFF", content category
 [tracking-protection-contenteff]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json


### PR DESCRIPTION
Bug 1425075 - config categories for each list
sample ads, analytics, and social list configs
refactor a default_disconnect_url config

To deploy:
1. [ ] Merge this PR to add this new logic
2. [ ] Merge [`shavar-list-creation-config` PR](https://github.com/mozilla-services/shavar-list-creation-config/pull/25) adding the ads, analytics, and social
3. [ ] Test the resulting lists on the stage server
4. [ ] Send the same PR adding ads, analytics, and social configs to https://github.com/mozilla-services/shavar-list-creation-config/blob/master/prod.ini
5. [ ] Test the resulting lists on the prod server