### PR TITLE
Ignore compiled python files in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /shavar_list_creation.ini
 *.log
 *-digest256
+
+# Python Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
This lets me use this repository as a git submodule without git complaining about untracked changes. As an example, see: https://github.com/mozilla/trackingprotection-tools.