### PR TITLE
Add support for tagged domains in list creation script

### DIFF
--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -99,20 +99,30 @@ output=fastblock3-track-digest256
 
 # DNT="", all top-level categories, fingerprinting tag
 [tracking-protection-base-fingerprinting]
+disconnect_tags=fingerprinting
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=base-fingerprinting-track-digest256
 
 # DNT="", Content category, fingerprinting tag
 [tracking-protection-content-fingerprinting]
+disconnect_tags=fingerprinting
 disconnect_categories=Content
 output=content-fingerprinting-track-digest256
 
 # DNT="", all top-level categories, cryptomining tag
 [tracking-protection-base-cryptomining]
+disconnect_tags=cryptominer
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=base-cryptomining-track-digest256
 
 # DNT="", Content category, cryptomining tag
 [tracking-protection-content-cryptomining]
+disconnect_tags=cryptominer
 disconnect_categories=Content
 output=content-cryptomining-track-digest256
+
+# A list to test multiple tag support. Not in the real config script
+[tracking-protection-test-multitag]
+disconnect_tags=cryptominer,fingerprinting
+disconnect_categories=Advertising,Analytics,Social,Disconnect
+output=test-multitag-track-digest256

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -96,3 +96,27 @@ output=fastblock2-trackwhite-digest256
 [fastblock3]
 blocklist_url=https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock3.json
 output=fastblock3-track-digest256
+
+# DNT="", all top-level categories, fingerprinting tag
+[tracking-protection-base-fingerprinting]
+disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
+output=base-fingerprinting-track-digest256
+
+# DNT="", Content category, fingerprinting tag
+[tracking-protection-content-fingerprinting]
+disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
+disconnect_categories=Content
+output=content-fingerprinting-track-digest256
+
+# DNT="", all top-level categories, cryptomining tag
+[tracking-protection-base-cryptomining]
+disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
+disconnect_categories=Advertising,Analytics,Social,Disconnect
+output=base-cryptomining-track-digest256
+
+# DNT="", Content category, cryptomining tag
+[tracking-protection-content-cryptomining]
+disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
+disconnect_categories=Content
+output=content-cryptomining-track-digest256

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -99,24 +99,20 @@ output=fastblock3-track-digest256
 
 # DNT="", all top-level categories, fingerprinting tag
 [tracking-protection-base-fingerprinting]
-disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=base-fingerprinting-track-digest256
 
 # DNT="", Content category, fingerprinting tag
 [tracking-protection-content-fingerprinting]
-disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
 disconnect_categories=Content
 output=content-fingerprinting-track-digest256
 
 # DNT="", all top-level categories, cryptomining tag
 [tracking-protection-base-cryptomining]
-disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
 disconnect_categories=Advertising,Analytics,Social,Disconnect
 output=base-cryptomining-track-digest256
 
 # DNT="", Content category, cryptomining tag
 [tracking-protection-content-cryptomining]
-disconnect_url=https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
 disconnect_categories=Content
 output=content-cryptomining-track-digest256


### PR DESCRIPTION
This PR adds support for parsing our the `fingerprinting` and `cryptomining` portions of the Disconnect list. I checked the logs for the generated lists and spot checked them against the domains generated by [a separate parser](https://github.com/mozilla/trackingprotection-tools/blob/master/DisconnectParser.py).