### PR TITLE
Move mapping from python to json file

### DIFF
--- a/disconnect_mapping.json
+++ b/disconnect_mapping.json
@@ -1,8 +1,4 @@
-# Started from https://github.com/mozilla-mobile/focus-android/blob/5868770104a8645c31b086a5e9916f4ddb507cb3/shavar-prod-lists/google_mapping.json
-disconnect_mapping = {
-
-  # google
-
+{
   "developers.google.com": "Social",
   "gmail.com": "Social",
   "mail.google.com": "Social",
@@ -13,10 +9,8 @@ disconnect_mapping = {
   "voice.google.com": "Social",
   "googlemail.com": "Social",
   "wave.google.com": "Social",
-
   "google-analytics.com": "Analytics",
   "postrank.com": "Analytics",
-
   "2mdn.net": "Advertising",
   "admeld.com": "Advertising",
   "admob.com": "Advertising",
@@ -35,30 +29,18 @@ disconnect_mapping = {
   "teracent.com": "Advertising",
   "teracent.net": "Advertising",
   "ytsa.net": "Advertising",
-
-  # facebook
-
   "facebook.com": "Social",
   "facebook.de": "Social",
   "facebook.fr": "Social",
   "facebook.net": "Social",
   "fb.com": "Social",
   "friendfeed.com": "Social",
-
   "atlassolutions.com": "Advertising",
-
-  # twitter
-
   "twitter.com": "Social",
   "twitter.jp": "Social",
   "twimg.com": "Social",
-
-  # now kicking to a godaddy default / looks abandoned
   "backtype.com": "Social",
-  # do we leave or remove?
-
   "crashlytics.com": "Analytics",
   "tweetdeck.com": "Analytics",
-
-  "ads-twitter.com": "Advertising",
+  "ads-twitter.com": "Advertising"
 }

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -16,10 +16,13 @@ import boto.s3.key
 from publicsuffixlist import PublicSuffixList
 from publicsuffixlist.update import updatePSL
 
-from disconnect_mapping import disconnect_mapping
-
 updatePSL()
 psl = PublicSuffixList()
+
+DISCONNECT_MAPPING_FILE = os.path.join(
+    os.path.dirname(__file__), 'disconnect_mapping.json')
+with open(DISCONNECT_MAPPING_FILE, 'r') as f:
+    disconnect_mapping = json.load(f)
 
 PLUGIN_SECTIONS = (
     "plugin-blocklist",


### PR DESCRIPTION
Moving the mapping to json makes it easier to import and use elsewhere. An example, I currently have to access it as a git submodule in https://github.com/mozilla/trackingprotection-tools/blob/1547cc88d83715f7fb1f12a84116188941ad556d/DisconnectParser.py#L9-L11. I'm going to publish that repository on PyPI to make it easier to use on databricks (and elsewhere), and will thus no longer be able to use the submodule solution.

We lose the high-level comments labeling Google, Facebook, and Twitter, but I think that's okay. I filed https://github.com/disconnectme/disconnect-tracking-protection/issues/70 to resolve the backtype dead domain.