### PR TITLE
Refactor the list parsing script to use a dedicated parser library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# pipenv
+Pipfile*
+
+# Output and test files
 /shavar_list_creation.ini
+prod.ini
+stage.ini
 *.log
 *-digest256
 

--- a/disconnect_mapping.json
+++ b/disconnect_mapping.json
@@ -1,8 +1,4 @@
-# Started from https://github.com/mozilla-mobile/focus-android/blob/5868770104a8645c31b086a5e9916f4ddb507cb3/shavar-prod-lists/google_mapping.json
-disconnect_mapping = {
-
-  # google
-
+{
   "developers.google.com": "Social",
   "gmail.com": "Social",
   "mail.google.com": "Social",
@@ -13,10 +9,8 @@ disconnect_mapping = {
   "voice.google.com": "Social",
   "googlemail.com": "Social",
   "wave.google.com": "Social",
-
   "google-analytics.com": "Analytics",
   "postrank.com": "Analytics",
-
   "2mdn.net": "Advertising",
   "admeld.com": "Advertising",
   "admob.com": "Advertising",
@@ -35,30 +29,18 @@ disconnect_mapping = {
   "teracent.com": "Advertising",
   "teracent.net": "Advertising",
   "ytsa.net": "Advertising",
-
-  # facebook
-
   "facebook.com": "Social",
   "facebook.de": "Social",
   "facebook.fr": "Social",
   "facebook.net": "Social",
   "fb.com": "Social",
   "friendfeed.com": "Social",
-
   "atlassolutions.com": "Advertising",
-
-  # twitter
-
   "twitter.com": "Social",
   "twitter.jp": "Social",
   "twimg.com": "Social",
-
-  # now kicking to a godaddy default / looks abandoned
   "backtype.com": "Social",
-  # do we leave or remove?
-
   "crashlytics.com": "Analytics",
   "tweetdeck.com": "Analytics",
-
-  "ads-twitter.com": "Advertising",
+  "ads-twitter.com": "Advertising"
 }

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -19,6 +19,11 @@ from publicsuffixlist.update import updatePSL
 updatePSL()
 psl = PublicSuffixList()
 
+DISCONNECT_MAPPING_FILE = os.path.join(
+    os.path.dirname(__file__), 'disconnect_mapping.json')
+with open(DISCONNECT_MAPPING_FILE, 'r') as f:
+    disconnect_mapping = json.load(f)
+
 PLUGIN_SECTIONS = (
     "plugin-blocklist",
     "plugin-blocklist-experiment",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto==2.40.0
 publicsuffixlist==0.4.0
 requests==2.10.0
+trackingprotection_tools==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto==2.40.0
 publicsuffixlist==0.4.0
 requests==2.10.0
-trackingprotection_tools==0.4.3
+trackingprotection_tools==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto==2.40.0
 publicsuffixlist==0.4.0
 requests==2.10.0
-trackingprotection_tools==0.4.2
+trackingprotection_tools==0.4.3


### PR DESCRIPTION
I've replicated the parsing logic in an [external library](https://github.com/mozilla/trackingprotection-tools/blob/4a1c0e1aea588e952264f5d0a98acdc075d36050/trackingprotection_tools/DisconnectParser.py). This PR switches `lists2safebrowsing` over to the external library.

This has a few clear benefits:
* I need to run analyses using the Disconnect list, so I've had to replicate the `lists2safebrowsing` logic. Prior to this I've had to effectively maintain two slightly different implementations with each structural change.
* The new parser has [fairly comprehensive test suite](https://github.com/mozilla/trackingprotection-tools/blob/4a1c0e1aea588e952264f5d0a98acdc075d36050/trackingprotection_tools/test/test_disconnect_parser.py), which will hopefully take a lot of the guess work and manual testing out of new structural changes to the list.
* The new structure allows us the flexibility to specify compound filters in the list creation script, i.e., "domains in (categoryA or categoryB) and in categoryC", I'm going to do this in an upcoming PR.

I recommended first reviewing and merging #71. We can rebase this PR to make the diffs much more readable.

This parser matches the output of the current script when run on `prod.ini`, with the exception of a minor bug in the current script. I can't do an exact hash comparison of the log outputs like I did in #71, since I removed some of the print statements from the original script. Instead, we can compare the missing domains file-by-file using the log output:

There are no domains in new files that aren't in the old files. You can verify this by running the current list creation script, copying the output to `original/`, running the script in this PR, and then running `ls -1 *.log | xargs -n 1 -I {} bash -c "echo {} & diff <(cat original/{} | sort) <(cat {} | sort) | grep '^>' | grep '\[m\]' | sort | uniq "`.

Following the same procedure as above we can look at the domains in the old lists that aren't in the new list (via `ls -1 *.log | xargs -n 1 -I {} bash -c "echo {} & diff <(cat original/{} | sort) <(cat {} | sort) | grep '^<' | grep '\[m\]' | sort | uniq "`):
```
adguard-ads-digest256.log
ads-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] vcmedia.vn >> vcmedia.vn/
allow-flashallow-digest256.log
analytics-track-digest256.log
base-cryptomining-track-digest256.log
baseeff-track-digest256.log
base-fingerprinting-track-digest256.log
base-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] rkdms.com >> rkdms.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
basew3c-track-digest256.log
block-flash-digest256.log
block-flashsubdoc-digest256.log
content-cryptomining-track-digest256.log
contenteff-track-digest256.log
content-fingerprinting-track-digest256.log
content-track-digest256.log
contentw3c-track-digest256.log
easylist-ads-digest256.log
easyprivacy-ads-digest256.log
except-flashallow-digest256.log
except-flash-digest256.log
except-flashinfobar-digest256.log
except-flashsubdoc-digest256.log
fanboyannoyance-ads-digest256.log
fanboysocial-ads-digest256.log
fastblock1-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
fastblock1-trackwhite-digest256.log
fastblock2-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
fastblock2-trackwhite-digest256.log
fastblock3-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
mozfullstaging-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] rkdms.com >> rkdms.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
mozfull-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] rkdms.com >> rkdms.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
mozplugin2-block-digest256.log
mozplugin-block-digest256.log
mozstdstaging-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] rkdms.com >> rkdms.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
mozstdstaging-trackwhite-digest256.log
mozstd-track-digest256.log
< [m] adonnetwork.com >> adonnetwork.com/
< [m] buzzcity.com >> buzzcity.com/
< [m] i-behavior.com >> i-behavior.com/
< [m] matomy.com >> matomy.com/
< [m] rkdms.com >> rkdms.com/
< [m] trackingsoft.com >> trackingsoft.com/
< [m] vcmedia.vn >> vcmedia.vn/
mozstd-trackwhite-digest256.log
social-track-digest256.log
```

Here we see that several files are missing the same set of domains. These domains are all in the list under multiple categories and/or organizations, and are actually added to the output lists multiple times in the current list creation script (which appears to be a bug based on [this line](https://github.com/mozilla-services/shavar-list-creation/blob/7291d5f7af861c11aef38848492a0f735032f6e0/lists2safebrowsing.py#L245-L246)). Our current script only adds them once, hence the difference. We should file follow-up bugs with Disconnect to address these duplicates.