### PR TITLE
Support new fingerprinting list format.

### DIFF
--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -8,7 +8,7 @@ s3_bucket=mmc-shavar
 
 [tracking-protection]
 # The location of the Disconnect list
-disconnect_categories=Advertising,Analytics,Social,Disconnect
+categories=Advertising|Analytics|Social|Disconnect
 # The location of the allowlist
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 # The filename of the generated data file.  This will be used as the S3 key
@@ -17,51 +17,51 @@ output=mozpub-track-digest256
 
 # DNT="", all categories except content category
 [tracking-protection-base]
-disconnect_categories=Advertising,Analytics,Social,Disconnect
+categories=Advertising|Analytics|Social|Disconnect
 output=base-track-digest256
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
-disconnect_categories=Advertising,Analytics,Social,Disconnect
+categories=Advertising|Analytics|Social|Disconnect
 output=baseeff-track-digest256
 
 # DNT="W3C", all categories except content category
 [tracking-protection-basew3c]
-disconnect_categories=Advertising,Analytics,Social,Disconnect
+categories=Advertising|Analytics|Social|Disconnect
 output=basew3c-track-digest256
 
 # DNT="", content category
 [tracking-protection-content]
-disconnect_categories=Content
+categories=Content
 output=content-track-digest256
 
 # DNT="", ads category
 [tracking-protection-ads]
-disconnect_categories=Advertising,Disconnect
+categories=Advertising|Disconnect
 output=ads-track-digest256
 
 # DNT="", analytics category
 [tracking-protection-analytics]
-disconnect_categories=Analytics,Disconnect
+categories=Analytics|Disconnect
 output=analytics-track-digest256
 
 # DNT="", social category
 [tracking-protection-social]
-disconnect_categories=Social,Disconnect
+categories=Social|Disconnect
 output=social-track-digest256
 
 # DNT="EFF", content category
 [tracking-protection-contenteff]
-disconnect_categories=Content
+categories=Content
 output=contenteff-track-digest256
 
 # DNT="W3C", content category
 [tracking-protection-contentw3c]
-disconnect_categories=Content
+categories=Content
 output=contentw3c-track-digest256
 
 [tracking-protection-testing]
-disconnect_categories=Advertising,Analytics,Social,Disconnect
+categories=Advertising|Analytics|Social|Disconnect
 allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 output=moztestpub-track-digest256
 
@@ -97,31 +97,22 @@ output=fastblock2-trackwhite-digest256
 blocklist_url=https://raw.githubusercontent.com/mozilla-services/shavar-experiments/master/fastblock3.json
 output=fastblock3-track-digest256
 
-# DNT="", all top-level categories, fingerprinting tag
 [tracking-protection-base-fingerprinting]
-disconnect_tags=fingerprinting
-disconnect_categories=Advertising,Analytics,Social,Disconnect
+categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
 
-# DNT="", Content category, fingerprinting tag
 [tracking-protection-content-fingerprinting]
-disconnect_tags=fingerprinting
-disconnect_categories=Content
+categories=Fingerprinting
+excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 
 # DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
-disconnect_categories=Cryptomining
+categories=Cryptomining
 output=base-cryptomining-track-digest256
 
 # DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
 disconnect_tags=cryptominer
-disconnect_categories=Content
+categories=Content
 output=content-cryptomining-track-digest256
-
-# A list to test multiple tag support. Not in the real config script
-[tracking-protection-test-multitag]
-disconnect_tags=fingerprinting,session-replay
-disconnect_categories=Advertising,Analytics,Social,Disconnect
-output=test-multitag-track-digest256


### PR DESCRIPTION
I recommend merging #71 and #72 first. After that, I'll rebase this and the diff should be much easier to read.

In https://github.com/mozilla-services/shavar-prod-lists/pull/56 Disconnect created a new top-level `Fingerprinting` category, which contains all fingerprinting domains irrespective of their tracking classification. This PR updates the list creation script to support compound and exclusion category filters, such as those specified in the new config (https://github.com/mozilla-services/shavar-list-creation-config/pull/45).

I migrated the `disconnect_categories` option over to a `categories` option with slightly different syntax. In the new format, `OR` category filters should use the `|` delimiter and `AND` category filters should use `,`. All of the old filters were `OR` (i.e., domains in category A or category B, etc), so these now use `|`. The new filters in https://github.com/mozilla-services/shavar-list-creation-config/pull/45 use a combination.

Using the procedure outlined in #72, I verified that these new changes don't cause any meaningful difference in the domains written to each list when compared to the original script. The exception is the fingerprinting domains (expected), and the set of duplicate domains that I flagged in https://github.com/mozilla-services/shavar-prod-lists/pull/56#pullrequestreview-213102271.