### PR TITLE
Add remote settings config check

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -18,18 +18,32 @@ from constants import (
 
 CONFIG = ConfigParser.SafeConfigParser(os.environ)
 CONFIG.read(['shavar_list_creation.ini'])
-REMOTE_SETTINGS_URL = ''
-if os.environ.get('SHAVAR_REMOTE_SETTINGS_URL', None):
-    REMOTE_SETTINGS_URL = CONFIG.get('main', 'remote_settings_url')
-REMOTE_SETTINGS_BUCKET = CONFIG.get('main', 'remote_settings_bucket')
-REMOTE_SETTINGS_COLLECTION = CONFIG.get('main', 'remote_settings_collection')
-REMOTE_SETTINGS_RECORD_PATH = ('/buckets/{bucket_name}'
-                               + '/collections/{collection_name}/records')
-REMOTE_SETTINGS_AUTH = ('', '')
-if (os.environ.get('SHAVAR_REMOTE_SETTINGS_USERNAME', None)
-    and os.environ.get('SHAVAR_REMOTE_SETTINGS_PASSWORD', None)):
-        REMOTE_SETTINGS_AUTH = (CONFIG.get('main', 'remote_settings_username'),
-                                CONFIG.get('main', 'remote_settings_password'))
+try:
+    REMOTE_SETTINGS_URL = ''
+    if os.environ.get('SHAVAR_REMOTE_SETTINGS_URL', None):
+        REMOTE_SETTINGS_URL = CONFIG.get('main', 'remote_settings_url')
+    REMOTE_SETTINGS_BUCKET = CONFIG.get('main', 'remote_settings_bucket')
+    REMOTE_SETTINGS_COLLECTION = CONFIG.get(
+        'main', 'remote_settings_collection'
+    )
+    REMOTE_SETTINGS_RECORD_PATH = ('/buckets/{bucket_name}'
+                                   + '/collections/{collection_name}/records')
+    REMOTE_SETTINGS_AUTH = ('', '')
+    auth_config_exists = (
+        os.environ.get('SHAVAR_REMOTE_SETTINGS_USERNAME', None)
+        and os.environ.get('SHAVAR_REMOTE_SETTINGS_PASSWORD', None)
+    )
+    if auth_config_exists:
+        REMOTE_SETTINGS_AUTH = (
+            CONFIG.get('main', 'remote_settings_username'),
+            CONFIG.get('main', 'remote_settings_password')
+        )
+except ConfigParser.NoOptionError as err:
+    REMOTE_SETTINGS_URL = ''
+    REMOTE_SETTINGS_AUTH = None
+    REMOTE_SETTINGS_BUCKET = ''
+    REMOTE_SETTINGS_COLLECTION = ''
+    REMOTE_SETTINGS_RECORD_PATH = ''
 
 
 def chunk_metadata(fp):

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -109,6 +109,15 @@ def check_upload_remote_settings_config(config, section):
 
 
 def new_data_to_publish_to_remote_settings(config, section, new):
+    remote_settings_config_exists = (REMOTE_SETTINGS_URL
+                                     and REMOTE_SETTINGS_BUCKET
+                                     and REMOTE_SETTINGS_COLLECTION
+                                     and REMOTE_SETTINGS_RECORD_PATH
+                                     and REMOTE_SETTINGS_AUTH)
+    if not remote_settings_config_exists:
+        print('Missing config(s) for Remote Settings')
+        return False
+
     # Check to see if update is needed on Remote Settings
     record = get_record_remote_settings(config.get(section, 'output'))
 


### PR DESCRIPTION
# About this PR
- [ ] Adding some default configuration for Remote Settings in case the `-config` repo is not updated with the Remote Settings config
- [ ] Graceful returns and logging for various errors surrounding config missing or be incorrect