### PR TITLE
Default upload_to_s3 as True

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -236,10 +236,10 @@ def publish_to_cloud(config, chunknum):
         if section == 'main':
             continue
 
-        upload_to_s3 = False
-        if (config.has_option(section, 's3_upload')
-                and config.getboolean(section, 's3_upload')):
-            upload_to_s3 = True
+        upload_to_s3 = True
+        if (config.has_option(section, "s3_upload")
+                and not config.getboolean(section, "s3_upload")):
+            upload_to_s3 = False
 
         upload_to_remote_setting = check_upload_remote_settings_config(
             config, section)


### PR DESCRIPTION
# About this PR
After running the https://github.com/mozilla-services/shavar-list-creation/pull/86 changes we noted that the S3 were acting differently. To make sure that old functionalities are not changed, this PR applies the following:
- [ ] Default of the `upload_to_s3` should be `True` unless specified in the list's config