### PR TITLE
Version tracking lists and publish to S3

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -98,3 +98,7 @@ TEST_DOMAIN_TEMPLATE = '%s.dummytracker.org'
 DEFAULT_DISCONNECT_LIST_CATEGORIES = [
     'Advertising|Analytics|Social|Disconnect']
 DEFAULT_DISCONNECT_LIST_TAGS = {}
+
+LIST_TYPE_ENTITY = 'Entity'
+LIST_TYPE_PLUGIN = 'Plugin'
+LIST_TYPE_TRACKER = 'Tracker'

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -510,10 +510,9 @@ def get_versioned_lists(config, chunknum, version):
     Checks `versioning_needed` in each sections then versions the tracker lists
     by overwriting the existing SafeBrowsing formatted files.
     '''
-    default_url = config.get('main', 'default_disconnect_url')
-    versioned_default_url = default_url.replace('master', version)
-    print('New default disconnect url is ' + versioned_default_url)
-    config.set('main', 'default_disconnect_url', versioned_default_url)
+    edit_config(
+        config, section='main', option='default_disconnect_url',
+        old_value='master', new_value=version)
     for section in config.sections():
         versioning_needed = (
             config.has_option(section, 'versioning_needed')

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -10,6 +10,7 @@ import sys
 import time
 import urllib2
 
+from packaging import version
 from publicsuffixlist import PublicSuffixList
 from publicsuffixlist.update import updatePSL
 
@@ -589,14 +590,14 @@ def main():
         shavar_prod_lists_branches = resp.json()
         for branch in shavar_prod_lists_branches:
             branch_name = branch.get('name')
-            try:
-                float(branch_name)
+            ver = version.parse(branch_name)
+            if isinstance(ver, version.Version):
                 get_versioned_lists(config, chunknum, version=branch_name)
                 print('*** Publish Versioned Lists ***')
                 publish_to_cloud(config, chunknum, check_versioning=True)
                 print('*** Revert Configs ***')
                 revert_config(config, branch_name)
-            except (ValueError, TypeError) as exc:
+            else:
                 print(branch_name + ' is not a versioning branch')
     else:
         print('Unable to get branches from shavar-prod-lists repo')

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -508,10 +508,10 @@ def revert_config(config, version):
 
 
 def get_versioned_lists(config, chunknum, version):
-    '''
+    """
     Checks `versioning_needed` in each sections then versions the tracker lists
     by overwriting the existing SafeBrowsing formatted files.
-    '''
+    """
     edit_config(
         config, section='main', option='default_disconnect_url',
         old_value='master', new_value=version)

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -468,20 +468,9 @@ def edit_config(config, section, option, old_value, new_value):
     )
 
 
-def version_configurations(config, section, version, revert=None):
+def version_configurations(config, section, version):
     initial_disconnect_url_val = 'master'
     initial_s3_key_value = 'tracking/'
-    if revert:
-        if config.has_option(section, 'disconnect_url'):
-            edit_config(
-                config, section, option='disconnect_url',
-                old_value=version, new_value=initial_disconnect_url_val)
-        if config.has_option(section, 's3_key'):
-            versioned_key = 'tracking/{ver}/'.format(ver=version)
-            edit_config(
-                config, section, option='s3_key',
-                old_value=versioned_key, new_value=initial_s3_key_value)
-        return
 
     if config.has_option(section, 'disconnect_url'):
         edit_config(
@@ -495,6 +484,20 @@ def version_configurations(config, section, version, revert=None):
             old_value=initial_s3_key_value, new_value=versioned_key)
 
 
+def revert_version_configurations(config, section, version):
+    initial_disconnect_url_val = 'master'
+    initial_s3_key_value = 'tracking/'
+    if config.has_option(section, 'disconnect_url'):
+        edit_config(
+            config, section, option='disconnect_url',
+            old_value=version, new_value=initial_disconnect_url_val)
+    if config.has_option(section, 's3_key'):
+        versioned_key = 'tracking/{ver}/'.format(ver=version)
+        edit_config(
+            config, section, option='s3_key',
+            old_value=versioned_key, new_value=initial_s3_key_value)
+
+
 def revert_config(config, version):
     edit_config(
         config=config, section='main', option='default_disconnect_url',
@@ -506,7 +509,7 @@ def revert_config(config, version):
         )
         if not versioning_needed:
             continue
-        version_configurations(config, section, version, revert=True)
+        revert_version_configurations(config, section, version)
 
 
 def get_versioned_lists(config, chunknum, version):

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -398,8 +398,6 @@ def main():
                 disconnect_mapping=DISCONNECT_MAPPING
             )
 
-            output_file, log_file = get_output_and_log_files(config, section)
-
             # load our allowlist
             allowed = set()
             try:
@@ -459,6 +457,7 @@ def main():
                 parser, list_categories, excluded_categories,
                 which_dnt, desired_tags)
 
+            output_file, log_file = get_output_and_log_files(config, section)
             # Write blocklist in a format compatible with safe browsing
             output_filename = config.get(section, "output")
             write_safebrowsing_blocklist(
@@ -467,8 +466,6 @@ def main():
             )
 
         if section in PLUGIN_SECTIONS:
-            output_file, log_file = get_output_and_log_files(config, section)
-
             # load the plugin blocklist
             blocked = set()
             blocklist_url = config.get(section, "blocklist")
@@ -480,6 +477,7 @@ def main():
                         continue
                     blocked.add(line)
 
+            output_file, log_file = get_output_and_log_files(config, section)
             process_plugin_blocklist(blocked, chunknum, output_file, log_file,
                                      section)
 

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -491,6 +491,20 @@ def version_configurations(config, section, version, revert=None):
             old_value=initial_s3_key_value, new_value=versioned_key)
 
 
+def revert_config(config, version):
+    edit_config(
+        config=config, section='main', option='default_disconnect_url',
+        old_value=version, new_value='master')
+    for section in config.sections():
+        versioning_needed = (
+            config.has_option(section, 'versioning_needed')
+                and config.get(section, 'versioning_needed')
+        )
+        if not versioning_needed:
+            continue
+        version_configurations(config, section, version, revert=True)
+
+
 def get_versioned_lists(config, chunknum, version):
     '''
     Checks `versioning_needed` in each sections then versions the tracker lists

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -520,9 +520,9 @@ def get_versioned_lists(config, chunknum, version):
         )
         if not versioning_needed:
             continue
-        print('Versioning for ' + config.get(section, 'output'))
-        default = config.get('main', 'default_disconnect_url')
-        print('Default disconnect URL: ' + default)
+        print('Version {ver} for {output}'.format(
+            ver=version, output=config.get(section, 'output'))
+        )
         version_configurations(config, section, version)
         output_file, log_file = get_tracker_lists(
             config, section, chunknum)
@@ -592,7 +592,9 @@ def main():
             try:
                 float(branch_name)
                 get_versioned_lists(config, chunknum, version=branch_name)
-                publish_to_cloud(config, chunknum)
+                print('*** Publish Versioned Lists ***')
+                publish_to_cloud(config, chunknum, check_versioning=True)
+                print('*** Revert Configs ***')
                 revert_config(config, branch_name)
             except (ValueError, TypeError) as exc:
                 print(branch_name + ' is not a versioning branch')

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -38,7 +38,8 @@ psl = PublicSuffixList()
 
 DISCONNECT_MAPPING = os.path.join(
     os.path.dirname(__file__), 'disconnect_mapping.json')
-GITHUB_API_URL = 'https://api.github.com/repos/mozilla-services/'
+GITHUB_API_URL = 'https://api.github.com/repos/mozilla-services'
+SHAVAR_PROD_LISTS_BRANCHES_PATH = '/shavar-prod-lists/branches'
 
 
 def get_output_and_log_files(config, section):
@@ -584,8 +585,8 @@ def main():
 
     publish_to_cloud(config, chunknum)
 
-    resp = requests.get(GITHUB_API_URL + 'shavar-prod-lists/branches')
-
+    # create and publish versioned lists
+    resp = requests.get(GITHUB_API_URL + SHAVAR_PROD_LISTS_BRANCHES_PATH)
     if resp:
         shavar_prod_lists_branches = resp.json()
         for branch in shavar_prod_lists_branches:

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -524,7 +524,7 @@ def get_versioned_lists(config, chunknum, version):
         )
         if not versioning_needed:
             continue
-        print('Version {ver} for {output}'.format(
+        print('\n*** Version {ver} for {output} ***'.format(
             ver=version, output=config.get(section, 'output'))
         )
         version_configurations(config, section, version)
@@ -595,15 +595,20 @@ def main():
             branch_name = branch.get('name')
             ver = version.parse(branch_name)
             if isinstance(ver, version.Version):
+                print('\n\n*** Start Versioining for {ver} ***'.format(
+                    ver=branch_name)
+                )
                 get_versioned_lists(config, chunknum, version=branch_name)
-                print('*** Publish Versioned Lists ***')
+                print('\n*** Publish Versioned Lists ***')
                 publish_to_cloud(config, chunknum, check_versioning=True)
-                print('*** Revert Configs ***')
+                print('\n*** Revert Configs ***')
                 revert_config(config, branch_name)
             else:
-                print(branch_name + ' is not a versioning branch')
+                print('\n\n*** {branch} is not a versioning branch ***'.format(
+                    branch=branch_name)
+                )
     else:
-        print('Unable to get branches from shavar-prod-lists repo')
+        print('\n\n*** Unable to get branches from shavar-prod-lists repo ***')
 
 
 if __name__ == "__main__":

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -544,6 +544,32 @@ def main():
 
     publish_to_cloud(config, chunknum)
 
+    shavar_prod_lists_branch = {
+      'name': '70',
+      'commit': {
+        'sha': '8ffa3c6d702002e9a357dd0042848c9418e0ef8a',
+        'url': 'https://api.github.com/repos/mozilla-services/shavar-prod-lists/commits/8ffa3c6d702002e9a357dd0042848c9418e0ef8a'
+      },
+      'protected': False
+    }
+    shavar_prod_lists_non_versioning_branch = {
+      'name': 'non-versioning-branch',
+      'commit': {
+        'sha': '8ffa3c6d702002e9a357dd0042848c9418e0ef8a',
+        'url': 'https://api.github.com/repos/mozilla-services/shavar-prod-lists/commits/8ffa3c6d702002e9a357dd0042848c9418e0ef8a'
+      },
+      'protected': False
+    }
+    # get shavar_prod_lists branches from git
+    shavar_prod_lists_branches = [shavar_prod_lists_branch, shavar_prod_lists_non_versioning_branch]
+    for branch in shavar_prod_lists_branches:
+        branch_name = branch.get('name')
+        try:
+            int(branch_name)
+            get_versioned_lists(config, chunknum, version=branch_name)
+        except ValueError as exc:
+            print(branch_name + ' is not a versioning branch')
+
 
 if __name__ == "__main__":
     main()

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -38,8 +38,10 @@ psl = PublicSuffixList()
 
 DISCONNECT_MAPPING = os.path.join(
     os.path.dirname(__file__), 'disconnect_mapping.json')
-GITHUB_API_URL = 'https://api.github.com/repos/mozilla-services'
-SHAVAR_PROD_LISTS_BRANCHES_PATH = '/shavar-prod-lists/branches'
+GITHUB_API_URL = 'https://api.github.com'
+SHAVAR_PROD_LISTS_BRANCHES_PATH = (
+    '/repos/mozilla-services/shavar-prod-lists/branches'
+)
 
 
 def get_output_and_log_files(config, section):

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -500,7 +500,7 @@ def revert_config(config, version):
     for section in config.sections():
         versioning_needed = (
             config.has_option(section, 'versioning_needed')
-                and config.get(section, 'versioning_needed')
+            and config.get(section, 'versioning_needed')
         )
         if not versioning_needed:
             continue
@@ -518,7 +518,7 @@ def get_versioned_lists(config, chunknum, version):
     for section in config.sections():
         versioning_needed = (
             config.has_option(section, 'versioning_needed')
-                and config.get(section, 'versioning_needed')
+            and config.get(section, 'versioning_needed')
         )
         if not versioning_needed:
             continue

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -242,7 +242,7 @@ def publish_to_cloud(config, chunknum, check_versioning=None):
         if check_versioning:
             versioning_needed = (
                 config.has_option(section, 'versioning_needed')
-                    and config.get(section, 'versioning_needed')
+                and config.get(section, 'versioning_needed')
             )
             if not versioning_needed:
                 continue

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -232,12 +232,21 @@ def publish_to_remote_settings(config, section):
     print('Uploaded to remote settings: %s' % list_name)
 
 
-def publish_to_cloud(config, chunknum):
+def publish_to_cloud(config, chunknum, check_versioning=None):
     # Optionally upload to S3. If s3_upload is set, then s3_bucket and s3_key
     # must be set.
     for section in config.sections():
         if section == 'main':
             continue
+
+        if check_versioning:
+            versioning_needed = (
+                config.has_option(section, 'versioning_needed')
+                    and config.get(section, 'versioning_needed')
+            )
+            if not versioning_needed:
+                continue
+            print('Publishing versioning lists for: ' + section)
 
         upload_to_s3 = True
         if (config.has_option(section, "s3_upload")

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -246,7 +246,7 @@ def publish_to_cloud(config, chunknum, check_versioning=None):
             )
             if not versioning_needed:
                 continue
-            print('Publishing versioning lists for: ' + section)
+            print('Publishing versioned lists for: ' + section)
 
         upload_to_s3 = True
         if (config.has_option(section, "s3_upload")

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -11,6 +11,9 @@ import boto.s3.key
 from constants import (
     DEFAULT_DISCONNECT_LIST_CATEGORIES,
     DNT_SECTIONS,
+    LIST_TYPE_ENTITY,
+    LIST_TYPE_TRACKER,
+    LIST_TYPE_PLUGIN,
     PLUGIN_SECTIONS,
     PRE_DNT_SECTIONS,
     WHITELIST_SECTIONS,
@@ -195,7 +198,7 @@ def publish_to_remote_settings(config, section):
     categories = []
     excluded_categories = []
     if (section in PRE_DNT_SECTIONS or section in DNT_SECTIONS):
-        list_type = 'Tracker'
+        list_type = LIST_TYPE_TRACKER
         if config.has_option(section, 'categories'):
             list_categories = config.get(section, 'categories').split(',')
         else:
@@ -211,9 +214,9 @@ def publish_to_remote_settings(config, section):
             for x in excluded:
                 excluded_categories.extend(x.split('|'))
     elif (section in PLUGIN_SECTIONS):
-        list_type = 'Plugin'
+        list_type = LIST_TYPE_PLUGIN
     elif (section in WHITELIST_SECTIONS):
-        list_type = 'Entity'
+        list_type = LIST_TYPE_ENTITY
 
     list_name = config.get(section, 'output')
     chunk_file = chunk_metadata(open(config.get(section, 'output'), 'rb'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ boto==2.40.0
 publicsuffixlist==0.4.0
 requests==2.10.0
 trackingprotection_tools==0.4.6
+packaging==19.2
 setuptools==40.8.0

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -30,6 +30,7 @@ output=mozpub-track-digest256
 [tracking-protection-base]
 categories=Advertising|Analytics|Social|Disconnect
 output=base-track-digest256
+versioning_needed=true
 
 # DNT="EFF", all categories except content category
 [tracking-protection-baseeff]
@@ -45,51 +46,60 @@ output=basew3c-track-digest256
 [tracking-protection-content]
 categories=Content
 output=content-track-digest256
+versioning_needed=true
 
 # DNT="", ads category
 [tracking-protection-ads]
 categories=Advertising|Disconnect
 output=ads-track-digest256
+versioning_needed=true
 
 # DNT="", analytics category
 [tracking-protection-analytics]
 categories=Analytics|Disconnect
 output=analytics-track-digest256
+versioning_needed=true
 
 # DNT="", social category
 [tracking-protection-social]
 categories=Social|Disconnect
 output=social-track-digest256
+versioning_needed=true
 
 [social-tracking-protection]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Facebook|Twitter|LinkedIn|YouTube
 output=social-tracking-protection-digest256
 s3_key=tracking/social-tracking-protection-digest256
+versioning_needed=true
 
 [social-tracking-protection-facebook]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Facebook
 output=social-tracking-protection-facebook-digest256
 s3_key=tracking/social-tracking-protection-facebook-digest256
+versioning_needed=true
 
 [social-tracking-protection-twitter]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=Twitter
 output=social-tracking-protection-twitter-digest256
 s3_key=tracking/social-tracking-protection-twitter-digest256
+versioning_needed=true
 
 [social-tracking-protection-linkedin]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=LinkedIn
 output=social-tracking-protection-linkedin-digest256
 s3_key=tracking/social-tracking-protection-linkedin-digest256
+versioning_needed=true
 
 [social-tracking-protection-youtube]
 disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json
 categories=YouTube
 output=social-tracking-protection-youtube-digest256
 s3_key=tracking/social-tracking-protection-youtube-digest256
+versioning_needed=true
 
 # DNT="EFF", content category
 [tracking-protection-contenteff]
@@ -141,19 +151,23 @@ output=fastblock3-track-digest256
 [tracking-protection-base-fingerprinting]
 categories=Advertising|Analytics|Social|Content,Fingerprinting
 output=base-fingerprinting-track-digest256
+versioning_needed=true
 
 [tracking-protection-content-fingerprinting]
 categories=Fingerprinting
 excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
+versioning_needed=true
 
 # DNT="", Cryptomining top-level category
 [tracking-protection-base-cryptomining]
 categories=Cryptomining
 output=base-cryptomining-track-digest256
+versioning_needed=true
 
 # DNT="", Content top-level category and `cryptomining` tag
 [tracking-protection-content-cryptomining]
 disconnect_tags=cryptominer
 categories=Content
 output=content-cryptomining-track-digest256
+versioning_needed=true


### PR DESCRIPTION
# About this PR
As mentioned in https://github.com/mozilla-services/shavar-list-creation/issues/90, adding versioning to S3 was pushed higher in the priority because we want versioning before merging new lists published from [Disconnect](https://github.com/mozilla-services/shavar-prod-lists/pull/76) to ascertain that the new lists are not unexpectedly breaking websites thus disrupting millions of users who use Firefox to surfing the web. This PR uses the versioned branch(s) available on [Shavar prod lists repo](https://github.com/mozilla-services/shavar-prod-lists) to publish versioned lists to S3

# Acceptance Criteria
- [ ] Creating and publishing lists works at it has before: lists are created and published under the default configurations using `master` and `tracking/{list_name}`. 
- [ ] Checks configuration(`.ini`) file to version lists
- [ ] Grabs branches from [Shavar prod lists repo](https://github.com/mozilla-services/shavar-prod-lists) and creates versioned lists
- [ ] Publishes versioned lists to S3 using the key `tracking/{version}/{list name}`

#
Depends on config changes https://github.com/mozilla-services/shavar-list-creation-config/pull/56