### PR TITLE
Graceful exit when Remote Settings returns a ConnectionError

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -263,9 +263,13 @@ def publish_to_cloud(config, chunknum, check_versioning=None):
         with open(config.get(section, 'output'), 'rb') as blob:
             new = chunk_metadata(blob)
             s3_upload_needed = new_data_to_publish_to_s3(config, section, new)
-            rs_upload_needed = new_data_to_publish_to_remote_settings(
-                config, section, new
-            )
+            try:
+                rs_upload_needed = new_data_to_publish_to_remote_settings(
+                    config, section, new
+                )
+            except requests.exceptions.ConnectionError as exc:
+                print('Connection Error on Remote Settings.')
+                rs_upload_needed = False
             if not s3_upload_needed and not rs_upload_needed:
                 print('No new data to publish for %s' % section)
                 continue


### PR DESCRIPTION
# About this PR
#93 is caused by Remote Settings endpoint not being available to Jenkins since Remote Settings is behind a VPN. This PR handles connection issue to Remote Settings and gracefully exits so that S3 can continue to run as it did.

# Acceptance Criteria
- [ ] Fix #93 