### PR TITLE
Publish versioned chunk num on s3

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -483,6 +483,8 @@ def version_configurations(config, section, version):
             config, section, option='s3_key',
             old_value=initial_s3_key_value, new_value=versioned_key)
 
+    config.set(section, 'chunk_key_version', version)
+
 
 def revert_version_configurations(config, section, version):
     initial_disconnect_url_val = 'master'

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -176,8 +176,19 @@ def publish_to_s3(config, section, chunknum):
     if config.has_option(section, 's3_key'):
         key = config.get(section, 's3_key')
 
-    chunk_key = os.path.join(
-        config.get(section, os.path.basename('output')), str(chunknum))
+    versioning_needed = (
+        config.has_option(section, 'versioning_needed')
+        and config.getboolean(section, 'versioning_needed')
+    )
+    if versioning_needed:
+        chunk_key = os.path.join(
+            config.get(section, os.path.basename('output')),
+            config.get(section, 'chunk_key_version'),
+            str(chunknum)
+        )
+    else:
+        chunk_key = os.path.join(
+            config.get(section, os.path.basename('output')), str(chunknum))
 
     if not bucket or not key:
         sys.stderr.write(

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -188,7 +188,9 @@ def publish_to_s3(config, section, chunknum):
         )
     else:
         chunk_key = os.path.join(
-            config.get(section, os.path.basename('output')), str(chunknum))
+            config.get(section, os.path.basename('output')),
+            str(chunknum)
+        )
 
     if not bucket or not key:
         sys.stderr.write(

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -180,10 +180,10 @@ def publish_to_s3(config, section, chunknum):
         config.has_option(section, 'versioning_needed')
         and config.getboolean(section, 'versioning_needed')
     )
-    if versioning_needed and config.has_option(section, 'chunk_key_version'):
+    if versioning_needed and config.has_option(section, 'version'):
         chunk_key = os.path.join(
             config.get(section, os.path.basename('output')),
-            config.get(section, 'chunk_key_version'),
+            config.get(section, 'version'),
             str(chunknum)
         )
     else:

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -180,7 +180,7 @@ def publish_to_s3(config, section, chunknum):
         config.has_option(section, 'versioning_needed')
         and config.getboolean(section, 'versioning_needed')
     )
-    if versioning_needed:
+    if versioning_needed and config.has_option(section, 'chunk_key_version'):
         chunk_key = os.path.join(
             config.get(section, os.path.basename('output')),
             config.get(section, 'chunk_key_version'),


### PR DESCRIPTION
# About this PR
To get the proper versioned list from S3 as requested on https://github.com/mozilla-services/shavar-list-creation/issues/90 its respective chunknum (timestamp of when the list was created) should also be available AND be differentiated from the lists created from the master branch. This PR solves that issue by creating a folder inside the chunknum folder of each list and storing the chunk num in that folder.

# Acceptance Criteria
- [ ] New folder created in the list chunk num folder
- [ ] Chunk num is stored in the respective versioned folder for a given list