### PR TITLE
Add versioned static test domain

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -271,7 +271,7 @@ def write_safebrowsing_blocklist(domains, output_name, allow_list, log_file,
     # Add a static test domain to list
     test_domain = TEST_DOMAIN_TEMPLATE % output_name
     if version:
-        test_domain = '{0}.{1}'.format(version, test_domain)
+        test_domain = '{0}-{1}'.format(version.replace('.', '-'), test_domain)
     added = add_domain_to_list(
         test_domain, previous_domains, allow_list, log_file, output
     )


### PR DESCRIPTION
# About this PR
While implementing features on Shavar service as mentioned in https://github.com/mozilla-services/shavar-list-creation/issues/90, in order to ascertain that the versioned list is being used by the client we need a test domain that only exists in the said versioned list. This PR adds a static versioned test domain in the versioned lists with the following naming convention: `<version>.<list name>.dummytracker.org` like `71.0.base-fingerprinting-track-digest256.dummytracker.org`

# Acceptance Criteria
- [ ] For each versioned list, a static test domain in the following format is added: `<version>.<list name>.dummytracker.org` like `71.0.base-fingerprinting-track-digest256.dummytracker.org`

# Practical Test
### Test that the domain is added to the list using log
1. Go to this [line](https://github.com/mozilla-services/shavar-list-creation/pull/103/commits/8c3d243a0acd54dca95a1074927e48ec21414b11#diff-8c5c15d9cbbefc2ec320aa3f2a253290R274)
2. Add an easily identifable print statement with the domain to be printed on the terminal
3. Run `python ./lists2safebrowsing.py` and check that each versioned list has a unique (versioned) static test domain
### Test that the versioned test domain is used by your client
1. In the browser, go to `about:config` and change the `browser.safebrowsing.provider.mozilla.updateURL` and `browser.safebrowsing.provider.mozilla.gethashURL` to use the staging Shavar
2. Stay on the `about:config` and change the `browser.safebrowsing.provider.mozilla.lists` to just `base-fingerprinting-track-digest256`
3. Go to `about:support` and copy the path listed on the `Profile Folder` row
4. On your laptop, go to the path copied in step 3 and go into the `safebrowsing` folder
5. Remove the files starting with `base-fingerprinting-track-digest256` in the `safebrowsing` folder
6. Back in your browser, go to `about:url-classifier` and under the `Provider` section click the `Trigger Update` button to get the latest changes
7. Refresh the `about:url-classifier` page and in the `URL` search box under `Search` section enter the versioned test URL with the following format `<version>-<list_name>.dummytracker.org` (e.g. `https://71-0-base-fingerprinting-track-digest256.dummytracker.org/test_not_blocked.png`)
8. Click the `Start searching` and check that the versioned test domain is found under the `Results` section in the corresponding category (following the example on step 7, the domain should show up in fingerprinting category).

#
Dependent on https://github.com/mozilla-services/shavar/pull/111