### PR TITLE
Add static test domains to versioned lists

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -270,15 +270,25 @@ def write_safebrowsing_blocklist(domains, output_name, allow_list, log_file,
 
     # Add a static test domain to list
     test_domain = TEST_DOMAIN_TEMPLATE % output_name
-    if version:
-        test_domain = '{0}-{1}'.format(version.replace('.', '-'), test_domain)
+    num_test_domain_added = 0
     added = add_domain_to_list(
         test_domain, previous_domains, allow_list, log_file, output
     )
     if added:
+        num_test_domain_added += 1
+
+    if version:
+        test_domain = '{0}-{1}'.format(version.replace('.', '-'), test_domain)
+        added = add_domain_to_list(
+            test_domain, previous_domains, allow_list, log_file, output
+        )
+        if added:
+            num_test_domain_added += 1
+
+    if num_test_domain_added > 0:
         # TODO?: hashdata_bytes += hashdata.digest_size
-        hashdata_bytes += 32
-        publishing += 1
+        hashdata_bytes += (32 * num_test_domain_added)
+        publishing += num_test_domain_added
 
     for d in domains:
         added = add_domain_to_list(


### PR DESCRIPTION
# About this PR
After the changes introduced in https://github.com/mozilla-services/shavar-list-creation/pull/103, QAs are unable to test that ETP works on https://senglehardt.com/test/trackingprotection/test_pages/ since the static test domains on versioned lists were replaced by versioned test domains (e.g. https://70-0-social-tracking-protection-facebook-digest256.dummytracker.org/ instead or https://social-tracking-protection-facebook-digest256.dummytracker.org/). Versioned lists should have static test domains and the test domains with version as the prefix so QAs can test that ETP works on all channels.

# Acceptance Criteria
- [ ] Lists created from the Master branch of `shavar-prod-lists` should only have the static test domain (e.g. https://social-tracking-protection-facebook-digest256.dummytracker.org/)
- [ ] All versioned lists should have both the static test domain and the versioned test domain (e.g. https://70-0-social-tracking-protection-facebook-digest256.dummytracker.org/ AND https://social-tracking-protection-facebook-digest256.dummytracker.org/)