### PR TITLE
Add unit tests for add_domain_to_list

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -36,7 +36,7 @@ from publish2cloud import (
 )
 
 updatePSL()
-psl = PublicSuffixList()
+psl = PublicSuffixList(only_icann=True)
 
 GITHUB_API_URL = 'https://api.github.com'
 SHAVAR_PROD_LISTS_BRANCHES_PATH = (
@@ -155,13 +155,14 @@ def add_domain_to_list(domain, previous_domains, allow_list, log_file, output):
     Returns `True` if a domain was added, `False` otherwise"""
     canon_d = canonicalize(domain)
     if (canon_d not in previous_domains) and (domain not in allow_list):
-        # check if the domain is in the public suffix list
+        # Check if the domain is in the public (ICANN) section of the
+        # Public Suffix List. See:
+        # https://github.com/mozilla-services/shavar-list-creation/issues/102
         # SafeBrowsing keeps trailing '/', PublicSuffix does not
         psl_d = canon_d.rstrip('/')
         if psl.publicsuffix(psl_d) == psl_d:
-            if log_file:
-                log_file.write("[Public Suffix] %s; Skipping.\n" % psl_d)
-            return False
+            raise ValueError("Domain '%s' is in the public section of "
+                             "the Public Suffix List" % psl_d)
     if log_file:
         log_file.write("[m] %s >> %s\n" % (domain, canon_d))
         log_file.write("[canonicalized] %s\n" % (canon_d))

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -154,15 +154,16 @@ def add_domain_to_list(domain, previous_domains, log_file, output):
 
     Returns `True` if a domain was added, `False` otherwise"""
     canon_d = canonicalize(domain)
-    if canon_d not in previous_domains:
-        # Check if the domain is in the public (ICANN) section of the
-        # Public Suffix List. See:
-        # https://github.com/mozilla-services/shavar-list-creation/issues/102
-        # SafeBrowsing keeps trailing '/', PublicSuffix does not
-        psl_d = canon_d.rstrip('/')
-        if psl.publicsuffix(psl_d) == psl_d:
-            raise ValueError("Domain '%s' is in the public section of "
-                             "the Public Suffix List" % psl_d)
+    if canon_d in previous_domains:
+        return False
+    # Check if the domain is in the public (ICANN) section of the Public
+    # Suffix List. See:
+    # https://github.com/mozilla-services/shavar-list-creation/issues/102
+    # SafeBrowsing keeps trailing '/', PublicSuffix does not
+    psl_d = canon_d.rstrip('/')
+    if psl.publicsuffix(psl_d) == psl_d:
+        raise ValueError("Domain '%s' is in the public section of the "
+                         "Public Suffix List" % psl_d)
     if log_file:
         log_file.write("[m] %s >> %s\n" % (domain, canon_d))
         log_file.write("[canonicalized] %s\n" % (canon_d))
@@ -268,7 +269,7 @@ def write_safebrowsing_blocklist(domains, output_name, log_file, chunk,
     """Generates safebrowsing-compatible blocklist from a set of `domains`.
 
     Args:
-      domains: a list of hostnames and/or hostname+paths to add to blocklist
+      domains: a set of hostnames and/or hostname+paths to add to blocklist
       chunk: The chunk number to use.
       output_file: A file-handle to the output file.
       log_file: A filehandle to the log file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ setuptools==40.8.0
 
 # test requirements
 pytest==4.6.9
+mock==3.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto==2.40.0
-publicsuffixlist==0.4.0
+publicsuffixlist==0.7.3
 requests==2.20.0
 trackingprotection_tools==0.4.6
 packaging==19.2

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -20,8 +20,6 @@ remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
 [tracking-protection]
 # The location of the Disconnect list
 categories=Advertising|Analytics|Social
-# The location of the allowlist
-allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 # The filename of the generated data file.  This will be used as the S3 key
 # name if s3_upload is enabled.  Leave blank for no local output.
 output=mozpub-track-digest256
@@ -113,7 +111,6 @@ output=contentw3c-track-digest256
 
 [tracking-protection-testing]
 categories=Advertising|Analytics|Social
-allowlist_url=https://raw.githubusercontent.com/mozilla-services/shavar-list-exceptions/master/allow_list
 output=moztestpub-track-digest256
 
 [plugin-blocklist]

--- a/tests/test_lists2safebrowsing.py
+++ b/tests/test_lists2safebrowsing.py
@@ -135,19 +135,21 @@ def test_add_domain_to_list():
     assert log_writes == expected_log_writes
 
 
-def test_add_domain_to_list_public_suffix():
-    """Test that add_domain_to_list skips public suffix domains."""
-    domain = "https://co.uk"
-    (added, canonicalized_domain, domain_hash, previous_domains,
-     log_writes, output) = _add_domain_to_list(domain, set(), [])
+def test_add_domain_to_list_psl_public():
+    """Test handling of ICANN public suffix list domains.
 
-    expected_log_writes = [call("[Public Suffix] %s; Skipping.\n" %
-                           canonicalized_domain.rstrip("/"))]
+    add_domain_to_list raises a ValueError
+    """
+    with pytest.raises(ValueError):
+        _add_domain_to_list("https://co.uk", set(), [])
 
-    assert not added
-    assert canonicalized_domain not in previous_domains
-    assert domain_hash.digest() not in output
-    assert log_writes == expected_log_writes
+
+def test_add_domain_to_list_psl_private():
+    """Test handling of private public suffix list domains.
+
+    add_domain_to_list adds them to the blocklist
+    """
+    assert _add_domain_to_list("https://apps.fbsbx.com", set(), [])[0]
 
 
 def test_add_domain_to_list_duplicate():

--- a/tests/test_lists2safebrowsing.py
+++ b/tests/test_lists2safebrowsing.py
@@ -109,7 +109,7 @@ def _add_domain_to_list(domain, previous_domains, output):
 
     with patch("test_lists2safebrowsing.open", mock_open()):
         with open("test_blocklist.log", "w") as log_file:
-            added = add_domain_to_list(domain, previous_domains, set(),
+            added = add_domain_to_list(domain, previous_domains,
                                        log_file, output)
             log_writes = log_file.write.call_args_list
 


### PR DESCRIPTION
Test that `add_domain_to_list` adds a domain to a blocklist and produces the expected log output. Also, test that `add_domain_to_list` does not add public suffix domains to the list. Finally, test that it does not add domains to the list twice. Closes #136

Note: currently `test_add_domain_to_list_duplicate` is failing for the reason described in https://github.com/mozilla-services/shavar-list-creation/issues/136#issuecomment-642851266