### PR TITLE
Add unit tests for blocklist and entity list generation

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -319,6 +319,7 @@ def write_safebrowsing_blocklist(domains, output_name, log_file, chunk,
     # Write safebrowsing-list format header
     output_string = "a:%u:32:%s\n" % (chunk, hashdata_bytes)
     output_string += ''.join(output)
+    # When testing on shavar-prod-lists no output file is provided
     if output_file:
         output_file.write(output_string)
 

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -496,13 +496,17 @@ def get_plugin_lists(config, section, chunknum):
     # load the plugin blocklist
     blocked = set()
     blocklist_url = config.get(section, "blocklist")
-    if blocklist_url:
-        for line in urllib2.urlopen(blocklist_url).readlines():
-            line = line.strip()
-            # don't add blank lines or comments
-            if not line or line.startswith('#'):
-                continue
-            blocked.add(line)
+    if not blocklist_url:
+        raise ValueError("The 'blocklist' key in section '%s' of the "
+                         "configuration file is empty. A plugin "
+                         "blocklist URL must be specified." % section)
+
+    for line in urllib2.urlopen(blocklist_url).readlines():
+        line = line.strip()
+        # don't add blank lines or comments
+        if not line or line.startswith('#'):
+            continue
+        blocked.add(line)
 
     output_file, log_file = get_output_and_log_files(config, section)
     process_plugin_blocklist(blocked, chunknum, output_file, log_file,

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -492,6 +492,25 @@ def get_entity_lists(config, section, chunknum):
     return output_file, log_file
 
 
+def get_plugin_lists(config, section, chunknum):
+    # load the plugin blocklist
+    blocked = set()
+    blocklist_url = config.get(section, "blocklist")
+    if blocklist_url:
+        for line in urllib2.urlopen(blocklist_url).readlines():
+            line = line.strip()
+            # don't add blank lines or comments
+            if not line or line.startswith('#'):
+                continue
+            blocked.add(line)
+
+    output_file, log_file = get_output_and_log_files(config, section)
+    process_plugin_blocklist(blocked, chunknum, output_file, log_file,
+                             section)
+
+    return output_file, log_file
+
+
 def edit_config(config, section, option, old_value, new_value):
     current = config.get(section, option)
     edited_config = current.replace(old_value, new_value)
@@ -636,20 +655,7 @@ def main():
                 config, section, chunknum)
 
         if section in PLUGIN_SECTIONS:
-            # load the plugin blocklist
-            blocked = set()
-            blocklist_url = config.get(section, "blocklist")
-            if blocklist_url:
-                for line in urllib2.urlopen(blocklist_url).readlines():
-                    line = line.strip()
-                    # don't add blank lines or comments
-                    if not line or line.startswith('#'):
-                        continue
-                    blocked.add(line)
-
-            output_file, log_file = get_output_and_log_files(config, section)
-            process_plugin_blocklist(blocked, chunknum, output_file, log_file,
-                                     section)
+            output_file, log_file = get_plugin_lists(config, section, chunknum)
 
         if section in ENTITYLIST_SECTIONS:
             output_file, log_file = get_entity_lists(config, section, chunknum)


### PR DESCRIPTION
Implement unit tests to validate Safe Browsing v2 blocklist generation. Include a test where the versioned test domain is not included in the blocklist and another test where both test domains are omitted, in order to ensure full branch coverage. Closes #137

Note: Right now these unit tests are failing because of the `previous_domains` bug mentioned in https://github.com/mozilla-services/shavar-list-creation/issues/136#issuecomment-642851266. They will be passing once https://github.com/mozilla-services/shavar-list-creation/pull/141 is merged.

Also closes #49.