### PR TITLE
Add unit tests for domain filtering and get_tracker_lists

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -202,7 +202,7 @@ def get_domains_from_filters(parser, category_filters,
     ----------
     parser : DisconnectParser
         An instance of the Disconnect list parser
-    category_filters : list of list of strings
+    category_filters : list of lists of strings
         A filter to restrict output to the specified top-level categories.
         Each filter should be a comma-separated list of top-level categories
         to restrict the list to. If more than one filter is provided, the
@@ -211,7 +211,7 @@ def get_domains_from_filters(parser, category_filters,
             `[['Advertising', 'Analytics'], ['Fingerprinting']]` will return
             domains in either the Advertising or Analytics category AND in the
             Fingerprinting category.
-    category_exclusion_filters : list of list of strings, optional
+    category_exclusion_filters : list of lists of strings, optional
         A filter to exclude domains from the specified top-level categories.
         The list format is the same as `category_filters`.
     dnt_filter : string, optional

--- a/tests/sample_blocklist.json
+++ b/tests/sample_blocklist.json
@@ -42,6 +42,14 @@
             "postrank.com"
           ]
         }
+      },
+      {
+        "ItIsATracker": {
+          "https://itisatracker.com/": [
+            "itisatracker.com"
+          ],
+          "dnt": "eff"
+        }
       }
     ],
     "Fingerprinting": [
@@ -80,10 +88,11 @@
     ],
     "Cryptomining": [
       {
-        "Webmining": {
-          "https://webmining.co/": [
-            "webmining.co"
-          ]
+        "CoinPot": {
+          "http://coinpot.co": [
+            "coinpot.co"
+          ],
+          "performance": "true"
         }
       }
     ]

--- a/tests/sample_blocklist.json
+++ b/tests/sample_blocklist.json
@@ -1,0 +1,91 @@
+{
+  "license": "",
+  "categories": {
+    "Advertising": [
+      {
+        "AdNetwork.net": {
+          "http://www.adnetwork.net/": [
+            "adnetwork.net"
+          ]
+        }
+      },
+      {
+        "AppCast": {
+          "https://appcast.io/": [
+            "appcast.io"
+          ]
+        }
+      }
+    ],
+    "Content": [
+      {
+        "Vimeo": {
+          "http://vimeo.com/": [
+            "vimeo.com",
+            "vimeocdn.com"
+          ]
+        }
+      }
+    ],
+    "Analytics": [
+      {
+        "ClickGuard": {
+          "https://www.clickguard.com/": [
+            "clickguard.com"
+          ]
+        }
+      },
+      {
+        "Google": {
+          "http://www.google.com/": [
+            "google-analytics.com",
+            "postrank.com"
+          ]
+        }
+      }
+    ],
+    "Fingerprinting": [
+      {
+        "AppCast": {
+          "https://appcast.io/": [
+            "appcast.io"
+          ]
+        }
+      },
+      {
+        "ClickGuard": {
+          "https://www.clickguard.com/": [
+            "clickguard.com"
+          ]
+        }
+      },
+      {
+        "dummytracker": {
+          "https://base-fingerprinting-track-digest256.dummytracker.org/": [
+            "base-fingerprinting-track-digest256.dummytracker.org/tracker.js"
+          ]
+        }
+      }
+    ],
+    "Social": [
+      {
+        "Twitter": {
+          "https://twitter.com/": [
+            "twimg.com",
+            "twitter.com",
+            "twitter.jp"
+          ]
+        }
+      }
+    ],
+    "Cryptomining": [
+      {
+        "Webmining": {
+          "https://webmining.co/": [
+            "webmining.co"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/sample_blocklist.json
+++ b/tests/sample_blocklist.json
@@ -94,6 +94,13 @@
           ],
           "performance": "true"
         }
+      },
+      {
+        "Webmining": {
+          "https://webmining.co/": [
+            "webmining.co"
+          ]
+        }
       }
     ]
   }

--- a/tests/test_lists2safebrowsing.py
+++ b/tests/test_lists2safebrowsing.py
@@ -12,6 +12,7 @@ from constants import (
     LIST_TYPE_ENTITY,
     LIST_TYPE_PLUGIN,
     STANDARD_ENTITY_SECTION,
+    TEST_DOMAIN_TEMPLATE
 )
 
 
@@ -93,8 +94,9 @@ CATEGORY_FILTER_TESTCASES = (
     (
         "union",
         [["Social", "Cryptomining"]],
-        {"twimg.com", "twitter.com", "twitter.jp", "coinpot.co"},
-        (4,)
+        {"twimg.com", "twitter.com", "twitter.jp", "coinpot.co",
+         "webmining.co"},
+        (5,)
     ),
     (
         "intersection",
@@ -187,6 +189,26 @@ PROCESS_PLUGIN_BLOCKLIST_EXPECTED_LOG_WRITE_INFO = (
         "e5a907c8ff3672a9cbc8f1d3a2110c5cbe7fdb31bb5edf44bc58a8f1553b23e2"),
     (CANONICALIZE_TESTCASES[1][1], CANONICALIZE_TESTCASES[1][2],
         "bc9a8f2b6fffd58571e188bb110545f8fb3af51cdf1a63696d505a9870a85be5"),
+)
+
+GET_TRACKER_LISTS_TESTCASES = (
+    (
+        "default", "tracking-protection",
+        {"adnetwork.net", "appcast.io", "clickguard.com",
+         "google-analytics.com", "postrank.com", "twimg.com",
+         "twitter.com", "twitter.jp"}
+    ),
+    (
+        "categories", "tracking-protection-base-fingerprinting",
+        {"appcast.io", "clickguard.com"}
+    ),
+    (
+        "excluded_categories", "tracking-protection-content-fingerprinting",
+        {"base-fingerprinting-track-digest256.dummytracker.org/tracker.js"}
+    ),
+    ("tags", "tracking-protection-base-cryptomining", {"coinpot.co"}),
+    ("invalid_tag", "tracking-protection-ads", set()),
+    ("version", "tracking-protection-content-cryptomining", set()),
 )
 
 GET_ENTITY_LISTS_TESTCASES = (
@@ -381,14 +403,14 @@ def test_get_domains_from_filters_category_exclusion(capsys, parser):
 
 def test_get_domains_from_filters_tags(capsys, parser):
     """Validate domain filtering with tag filters."""
-    category_filters = [["Social", "Cryptomining"]]
+    category_filters = [["Cryptomining"]]
     tag_filters = "performance"
 
     output = l2s.get_domains_from_filters(parser, category_filters,
                                           tag_filters=tag_filters)
 
     expected_output = {"coinpot.co"}
-    expected_print = _get_expected_print(category_filters, (4,))
+    expected_print = _get_expected_print(category_filters, (2,))
     expected_print += " * removing 1 rule(s) due to DNT exceptions\n"
     expected_print += (" * found 1 rule(s) with filter %s. Filtered "
                        "output to 1.\n" % tag_filters)
@@ -603,3 +625,53 @@ def test_get_plugin_lists_empty_url(chunknum):
 
     with pytest.raises(ValueError):
         l2s.get_plugin_lists(config, section, chunknum)
+
+
+@pytest.mark.parametrize(
+    "section,domains,testcase",
+    [pytest.param(section, domains, id, id=id)
+        for id, section, domains in GET_TRACKER_LISTS_TESTCASES]
+)
+def test_get_tracker_lists(parser, chunknum, section, domains, testcase):
+    """Test creating a tracker blocklist from a configuration section."""
+    config = ConfigParser.ConfigParser()
+    config.readfp(open("sample_shavar_list_creation.ini"))
+    version = None
+
+    if testcase == "default":
+        config.remove_option(section, "categories")
+    elif testcase == "tags":
+        config.set(section, "disconnect_tags", "performance,session-replay")
+    elif testcase == "invalid_tag":
+        config.set(section, "disconnect_tags", "invalid_tag")
+    elif testcase == "version":
+        version = "78.0"
+        config.set(section, "version", version)
+
+    with patch("lists2safebrowsing.DisconnectParser", return_value=parser), \
+            patch("lists2safebrowsing.open", mock_open()) as mocked_open:
+        if testcase == "invalid_tag":
+            with pytest.raises(ValueError):
+                l2s.get_tracker_lists(config, section, chunknum)
+            return
+        output_file, _ = l2s.get_tracker_lists(config, section, chunknum)
+
+    open_calls = mocked_open.call_args_list
+    output_filename = config.get(section, "output")
+    expected_open_calls = [call(output_filename, "wb"),
+                           call(output_filename + ".log", "w")]
+
+    output_write = output_file.write.call_args
+    test_domains = [TEST_DOMAIN_TEMPLATE % output_filename + "/"]
+    if version:
+        test_domains.append("%s-%s" % (version.replace(".", "-"),
+                                       test_domains[0]))
+    expected_domains = test_domains + [l2s.canonicalize(d) for d in domains]
+    expected_hashes = [hashlib.sha256(d.encode("utf-8")).digest()
+                       for d in expected_domains]
+    expected_bytes = hashlib.sha256().digest_size * len(expected_hashes)
+    expected_header = b"a:%d:32:%d\n" % (chunknum, expected_bytes)
+    expected_output = expected_header + b"".join(expected_hashes)
+
+    assert open_calls == expected_open_calls
+    assert output_write == call(expected_output)


### PR DESCRIPTION
This PR adds:

-  a unit test that validates the implementation of `get_domains_from_category_filters`
- a unit test that confirms that `get_domains_from_category_filters` raises a `ValueError` when receiving invalid input
- a sample blocklist JSON file to be used in the tests

**Update**: the following have been added to this PR:

- unit tests for `get_domains_from_filters`
- unit tests for `get_tracker_lists`



