### PR TITLE
Create config file before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           name: Run unit tests
           command: |
             source ~/venv/bin/activate
+            cp sample_shavar_list_creation.ini shavar_list_creation.ini
             mkdir test-results
             python -m pytest -v --junitxml=test-results/junit.xml
       - store_test_results:


### PR DESCRIPTION
Add a CircleCI step that copies `sample_shavar_list_creation.ini` to `shavar_list_creation.ini`, in order to prevent the tests from failing.