### PR TITLE
Configure Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
             source ~/venv/bin/activate
             cp sample_shavar_list_creation.ini shavar_list_creation.ini
             mkdir test-results
-            python -m pytest -v --junitxml=test-results/junit.xml
+            python -m pytest -v --junitxml=test-results/junit.xml --cov=. --cov-report=xml --cov-branch
+      - run:
+          name: Upload coverage report to Codecov
+          command: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
               path: test-results

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ stage.ini
 __pycache__/
 *.py[cod]
 *$py.class
+
+# coverage files
+.coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ shavar-list-creation
 ====================
 
 [![Build Status](https://circleci.com/gh/mozilla-services/shavar-list-creation.svg?style=shield)](https://circleci.com/gh/mozilla-services/shavar-list-creation)
+[![codecov](https://codecov.io/gh/mozilla-services/shavar-list-creation/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla-services/shavar-list-creation)
 
 This script fetches blocklist `.json` from urls (such as
 [shavar-prod-lists](https://github.com/mozilla-services/shavar-prod-lists)) and

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ generates safebrowsing-compatible digest list files to be served by
 3. Run the unit tests (currently under development):
 
     ```
-    python -m pytest -v
+    python -m pytest -v --cov=. --cov-branch
     ```
 
 4. Copy the `sample_shavar_list_creation.ini` file to

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ generates safebrowsing-compatible digest list files to be served by
     pip install -r requirements.txt
     ```
 
-3. Run the unit tests (currently under development):
-
-    ```
-    python -m pytest -v --cov=. --cov-branch
-    ```
-
-4. Copy the `sample_shavar_list_creation.ini` file to
+3. Copy the `sample_shavar_list_creation.ini` file to
    `shavar_list_creation.ini`:
 
     ```
     cp sample_shavar_list_creation.ini shavar_list_creation.ini
+    ```
+
+4. Run the unit tests (currently under development):
+
+    ```
+    python -m pytest -v --cov=. --cov-branch
     ```
 
 5. Run the `lists2safebrowsing.py` script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ setuptools==40.8.0
 
 # test requirements
 pytest==4.6.9
+pytest-cov==2.10.0


### PR DESCRIPTION
This PR:
    
-  Configures coverage reporting and Codecov integration
-  Corrects the order of instructions in the README, to prevent the tests from failing because there is no configuration file.
