### PR TITLE
Configure coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
             source ~/venv/bin/activate
             cp sample_shavar_list_creation.ini shavar_list_creation.ini
             mkdir test-results
-            python -m pytest -v --junitxml=test-results/junit.xml --cov=. --cov-report=html --cov-branch
+            python -m pytest -v --junitxml=test-results/junit.xml --cov=. \
+            --cov-report=term --cov-report=html --cov-branch
             coverage-badge -o coverage.svg
       - store_test_results:
               path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
             source ~/venv/bin/activate
             cp sample_shavar_list_creation.ini shavar_list_creation.ini
             mkdir test-results
-            python -m pytest -v --junitxml=test-results/junit.xml
+            python -m pytest -v --junitxml=test-results/junit.xml --cov=. --cov-report=html --cov-branch
       - store_test_results:
               path: test-results
+      - store_artifacts:
+              path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
             virtualenv ~/venv
             source ~/venv/bin/activate
             pip install -r requirements.txt
+            pip install coverage-badge
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
@@ -24,7 +25,10 @@ jobs:
             cp sample_shavar_list_creation.ini shavar_list_creation.ini
             mkdir test-results
             python -m pytest -v --junitxml=test-results/junit.xml --cov=. --cov-report=html --cov-branch
+            coverage-badge -o coverage.svg
       - store_test_results:
               path: test-results
       - store_artifacts:
               path: htmlcov
+      - store_artifacts:
+              path: coverage.svg

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ stage.ini
 __pycache__/
 *.py[cod]
 *$py.class
+
+# coverage files
+.coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ shavar-list-creation
 ====================
 
 [![Build Status](https://circleci.com/gh/mozilla-services/shavar-list-creation.svg?style=shield)](https://circleci.com/gh/mozilla-services/shavar-list-creation)
+[![Coverage](https://circleci.com/api/v1.1/project/github/mozilla-services/shavar-list-creation/latest/artifacts/0/coverage.svg?branch=main)](https://circleci.com/api/v1.1/project/github/mozilla-services/shavar-list-creation/latest/artifacts/0/htmlcov/index.html?branch=main)
 
 This script fetches blocklist `.json` from urls (such as
 [shavar-prod-lists](https://github.com/mozilla-services/shavar-prod-lists)) and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 shavar-list-creation
 ====================
 
-[![Build Status](https://circleci.com/gh/mozilla-services/shavar-list-creation.svg?style=shield)](https://circleci.com/gh/mozilla-services/shavar-list-creation)
+[![Build Status](https://circleci.com/gh/mozilla-services/shavar-list-creation/tree/main.svg?style=shield)](https://circleci.com/gh/mozilla-services/shavar-list-creation/tree/main)
 [![Coverage](https://circleci.com/api/v1.1/project/github/mozilla-services/shavar-list-creation/latest/artifacts/0/coverage.svg?branch=main)](https://circleci.com/api/v1.1/project/github/mozilla-services/shavar-list-creation/latest/artifacts/0/htmlcov/index.html?branch=main)
 
 This script fetches blocklist `.json` from urls (such as

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ generates safebrowsing-compatible digest list files to be served by
 3. Run the unit tests (currently under development):
 
     ```
-    python -m pytest -v
+    python -m pytest -v --cov=. --cov-branch
     ```
 
 4. Copy the `sample_shavar_list_creation.ini` file to

--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ generates safebrowsing-compatible digest list files to be served by
     pip install -r requirements.txt
     ```
 
-3. Run the unit tests (currently under development):
-
-    ```
-    python -m pytest -v --cov=. --cov-branch
-    ```
-
-4. Copy the `sample_shavar_list_creation.ini` file to
+3. Copy the `sample_shavar_list_creation.ini` file to
    `shavar_list_creation.ini`:
 
     ```
     cp sample_shavar_list_creation.ini shavar_list_creation.ini
+    ```
+
+4. Run the unit tests (currently under development):
+
+    ```
+    python -m pytest -v --cov=. --cov-branch
     ```
 
 5. Run the `lists2safebrowsing.py` script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ setuptools==40.8.0
 
 # test requirements
 pytest==4.6.9
+pytest-cov==2.10.0
 mock==3.0.5


### PR DESCRIPTION
This PR:

- Configures coverage reporting
- Corrects the order of instructions in the README, to prevent the tests from failing because there is no configuration file.
