### PR TITLE
Handle requests.exceptions.ReadTimeout

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -300,7 +300,8 @@ def publish_to_cloud(config, chunknum, check_versioning=None):
                 rs_upload_needed = new_data_to_publish_to_remote_settings(
                     config, section, new
                 )
-            except requests.exceptions.ConnectTimeout as exc:
+            except (requests.exceptions.ConnectTimeout,
+                    requests.exceptions.ReadTimeout) as exc:
                 print('Connection timed out on Remote Settings.')
                 rs_upload_needed = False
             if not s3_upload_needed and not rs_upload_needed:


### PR DESCRIPTION
# About this PR
Handle error on stage from Remote Settings
```
------ tracking-protection-content-cryptomining ------
-->blocklist: https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json)
 * filter ['Content'] matched 483 domains
 * filter ['Cryptomining'] matched 69 domains. Reduced set to 0 items.
 * removing 1 rule(s) due to DNT exceptions
Tracking protection(tracking-protection-content-cryptomining): publishing 1 items; file size 51
Traceback (most recent call last):
  File "lists2safebrowsing.py", line 684, in <module>
    main()
  File "lists2safebrowsing.py", line 672, in main
    publish_to_cloud(config, chunknum)
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/publish2cloud.py", line 301, in publish_to_cloud
    config, section, new
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/publish2cloud.py", line 131, in new_data_to_publish_to_remote_settings
    record = get_record_remote_settings(config.get(section, 'output'))
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/publish2cloud.py", line 83, in get_record_remote_settings
    resp = requests.get(record_url, auth=REMOTE_SETTINGS_AUTH, timeout=10)
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/lib/python2.7/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/lib/python2.7/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/lib/python2.7/site-packages/requests/sessions.py", line 524, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/lib/python2.7/site-packages/requests/sessions.py", line 637, in send
    r = adapter.send(request, **kwargs)
  File "/home/jenkins/slave/workspace/pipelines/ShavarListCreation/shavar-list-creation/lib/python2.7/site-packages/requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='settings-writer.stage.mozaws.net', port=443): Read timed out. (read timeout=10) 
```

# Acceptance Criteria
- [ ] Error no longer happens on Staging Jenkins
- [ ] Set publish to Remote Settings as `False` in list creation config