### PR TITLE
Update sample configuration with new fingerprinting category name

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -208,9 +208,9 @@ def get_domains_from_filters(parser, category_filters,
         to restrict the list to. If more than one filter is provided, the
         intersection of the filters is returned.
         Example:
-            `[['Advertising', 'Analytics'], ['Fingerprinting']]` will return
-            domains in either the Advertising or Analytics category AND in the
-            Fingerprinting category.
+            `[['Advertising', 'Analytics'], ['FingerprintingInvasive']]`
+            will return domains in either the Advertising or Analytics
+            category AND in the FingerprintingInvasive category.
     category_exclusion_filters : list of lists of strings, optional
         A filter to exclude domains from the specified top-level categories.
         The list format is the same as `category_filters`.

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -133,12 +133,12 @@ s3_key=entity/google-trackwhite-digest256
 versioning_needed=true
 
 [tracking-protection-base-fingerprinting]
-categories=Advertising|Analytics|Social|Content,Fingerprinting
+categories=Advertising|Analytics|Social|Content,FingerprintingInvasive
 output=base-fingerprinting-track-digest256
 versioning_needed=true
 
 [tracking-protection-content-fingerprinting]
-categories=Fingerprinting
+categories=FingerprintingInvasive
 excluded_categories=Advertising|Analytics|Social|Content
 output=content-fingerprinting-track-digest256
 versioning_needed=true

--- a/tests/sample_blocklist.json
+++ b/tests/sample_blocklist.json
@@ -52,7 +52,7 @@
         }
       }
     ],
-    "Fingerprinting": [
+    "FingerprintingInvasive": [
       {
         "AppCast": {
           "https://appcast.io/": [

--- a/tests/test_lists2safebrowsing.py
+++ b/tests/test_lists2safebrowsing.py
@@ -112,13 +112,13 @@ CATEGORY_FILTER_TESTCASES = (
     ),
     (
         "intersection",
-        [["Advertising"], ["Fingerprinting"]],
+        [["Advertising"], ["FingerprintingInvasive"]],
         {"appcast.io"},
         (2, (3, 1))
     ),
     (
         "union_intersection",
-        [["Advertising", "Analytics"], ["Fingerprinting"]],
+        [["Advertising", "Analytics"], ["FingerprintingInvasive"]],
         {"appcast.io", "clickguard.com"},
         (6, (3, 2))
     ),
@@ -472,7 +472,7 @@ def test_get_domains_from_filters(capsys, parser):
 def test_get_domains_from_filters_category_exclusion(capsys, parser):
     """Validate domain filtering with category exclusion filters."""
     category_filters = [["Advertising"]]
-    category_exclusion_filters = [["Fingerprinting"]]
+    category_exclusion_filters = [["FingerprintingInvasive"]]
 
     output = l2s.get_domains_from_filters(parser, category_filters,
                                           category_exclusion_filters)


### PR DESCRIPTION
# About this PR
According to changes on https://github.com/mozilla-services/shavar-prod-lists/pull/284 we are now using "FingerprintInvasive" instead of "Fingerprint" category

# Notes
Related to https://github.com/mozilla-services/shavar-prod-lists/pull/284