### PR TITLE
Order domains alphanumerically in safebrowsing lists

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -149,27 +149,27 @@ def canonicalize(d):
     return _url
 
 
-def add_domain_to_list(domain, previous_domains, log_file, output):
+def add_domain_to_list(domain, canonicalized_domain, previous_domain,
+                       log_file, output):
     """Prepare domain to be added to output list.
 
     Returns `True` if a domain was added, `False` otherwise"""
-    canon_d = canonicalize(domain)
-    if canon_d in previous_domains:
+    if canonicalized_domain == previous_domain:
         return False
     # Check if the domain is in the public (ICANN) section of the Public
     # Suffix List. See:
     # https://github.com/mozilla-services/shavar-list-creation/issues/102
     # SafeBrowsing keeps trailing '/', PublicSuffix does not
-    psl_d = canon_d.rstrip('/')
+    psl_d = canonicalized_domain.rstrip('/')
     if psl.publicsuffix(psl_d) == psl_d:
         raise ValueError("Domain '%s' is in the public section of the "
                          "Public Suffix List" % psl_d)
+    domain_hash = hashlib.sha256(canonicalized_domain)
     if log_file:
-        log_file.write("[m] %s >> %s\n" % (domain, canon_d))
-        log_file.write("[canonicalized] %s\n" % (canon_d))
-        log_file.write("[hash] %s\n" % hashlib.sha256(canon_d).hexdigest())
-    previous_domains.add(canon_d)
-    output.append(hashlib.sha256(canon_d).digest())
+        log_file.write("[m] %s >> %s\n" % (domain, canonicalized_domain))
+        log_file.write("[canonicalized] %s\n" % (canonicalized_domain))
+        log_file.write("[hash] %s\n" % domain_hash.hexdigest())
+    output.append(domain_hash.digest())
     return True
 
 
@@ -282,8 +282,8 @@ def write_safebrowsing_blocklist(domains, output_name, log_file, chunk,
     # Total number of bytes, 0 % 32
     hashdata_bytes = 0
 
-    # Remember previous domains so we don't print them more than once
-    previous_domains = set()
+    # Remember the previous domain so we don't print it more than once
+    previous_domain = None
 
     # Array holding hash bytes to be written to f_out. We need the total bytes
     # before writing anything.
@@ -291,30 +291,41 @@ def write_safebrowsing_blocklist(domains, output_name, log_file, chunk,
 
     # Add a static test domain to list
     test_domain = TEST_DOMAIN_TEMPLATE % output_name
+    canonicalized_domain = canonicalize(test_domain)
     num_test_domain_added = 0
-    added = add_domain_to_list(test_domain, previous_domains, log_file, output)
+    added = add_domain_to_list(test_domain, canonicalized_domain,
+                               previous_domain, log_file, output)
     if added:
         num_test_domain_added += 1
+        previous_domain = canonicalized_domain
 
     if version:
         test_domain = '{0}-{1}'.format(version.replace('.', '-'), test_domain)
-        added = add_domain_to_list(
-            test_domain, previous_domains, log_file, output
-        )
+        canonicalized_domain = canonicalize(test_domain)
+        added = add_domain_to_list(test_domain, canonicalized_domain,
+                                   previous_domain, log_file, output)
         if added:
             num_test_domain_added += 1
+            previous_domain = canonicalized_domain
 
     if num_test_domain_added > 0:
         # TODO?: hashdata_bytes += hashdata.digest_size
         hashdata_bytes += (32 * num_test_domain_added)
         publishing += num_test_domain_added
 
-    for d in domains:
-        added = add_domain_to_list(d, previous_domains, log_file, output)
+    domains = [(d, canonicalize(d)) for d in domains]
+    # Sort the domains before writing their hashes to the safebrowsing
+    # list file to ensure that changes in the order of domains will not
+    # cause unnecessary updates
+    domains.sort(key=lambda d: d[1])
+    for domain, canonicalized_domain in domains:
+        added = add_domain_to_list(domain, canonicalized_domain,
+                                   previous_domain, log_file, output)
         if added:
             # TODO?: hashdata_bytes += hashdata.digest_size
             hashdata_bytes += 32
             publishing += 1
+            previous_domain = canonicalized_domain
 
     # Write safebrowsing-list format header
     output_string = "a:%u:32:%s\n" % (chunk, hashdata_bytes)

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -285,8 +285,8 @@ def write_safebrowsing_blocklist(domains, output_name, log_file, chunk,
     # Remember the previous domain so we don't print it more than once
     previous_domain = None
 
-    # Array holding hash bytes to be written to f_out. We need the total bytes
-    # before writing anything.
+    # Array holding hash bytes to be written to output_file. We need the
+    # total bytes before writing anything
     output = []
 
     # Add a static test domain to list
@@ -597,7 +597,7 @@ def revert_config(config, version):
 
 def get_versioned_lists(config, chunknum, version):
     """
-    Checks `versioning_needed` in each sections then versions the tracker lists
+    Checks `versioning_needed` in each section then versions the tracker lists
     by overwriting the existing SafeBrowsing formatted files.
     """
     edit_config(

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -344,10 +344,11 @@ def process_entitylist(incoming, chunk, output_file, log_file, list_variant):
     Expects a dict from a loaded JSON blob.
     """
     publishing = 0
-    urls = set()
     hashdata_bytes = 0
     output = []
+
     for name, entity in sorted(incoming.items()):
+        urls = set()
         name = name.encode('utf-8')
         for prop in entity['properties']:
             for res in entity['resources']:
@@ -355,21 +356,21 @@ def process_entitylist(incoming, chunk, output_file, log_file, list_variant):
                 res = res.encode('utf-8')
                 if prop == res:
                     continue
-                d = canonicalize('%s/?resource=%s' % (prop, res))
-                h = hashlib.sha256(d)
-                if log_file:
-                    log_file.write(
-                        "[entity] %s >> (canonicalized) %s, hash %s\n"
-                        % (name, d, h.hexdigest())
-                    )
-                urls.add(d)
-                publishing += 1
-                hashdata_bytes += 32
-                output.append(hashlib.sha256(d).digest())
+                urls.add(canonicalize('%s/?resource=%s' % (prop, res)))
+        urls = sorted(urls)
+        for url in urls:
+            h = hashlib.sha256(url)
+            if log_file:
+                log_file.write(
+                    "[entity] %s >> (canonicalized) %s, hash %s\n"
+                    % (name, url, h.hexdigest())
+                )
+            publishing += 1
+            hashdata_bytes += 32
+            output.append(hashlib.sha256(url).digest())
 
     # Write the data file
     output_file.write("a:%u:32:%s\n" % (chunk, hashdata_bytes))
-    # FIXME: we should really sort the output
     for o in output:
         output_file.write(o)
 

--- a/tests/test_lists2safebrowsing.py
+++ b/tests/test_lists2safebrowsing.py
@@ -131,17 +131,23 @@ VERSIONED_TEST_DOMAIN_HASH = (b"C]~\x9e\xfeLL\xba\xf5\x17k!5\xe4t\xc4\xcc"
 DUMMYTRACKER_DOMAIN_HASH = (b"\xe5\xa9\x07\xc8\xff6r\xa9\xcb\xc8\xf1\xd3"
                             "\xa2\x11\x0c\\\xbe\x7f\xdb1\xbb^\xdfD\xbcX"
                             "\xa8\xf1U;#\xe2")
+GOOGLE_DOMAIN_HASH = (b"\xbc\x9a\x8f+o\xff\xd5\x85q\xe1\x88\xbb\x11\x05E"
+                      "\xf8\xfb:\xf5\x1c\xdf\x1acimPZ\x98p\xa8[\xe5")
+EXAMPLE_DOMAIN_HASH = (b"s\xd9\x86\xe0\t\x06_\x18,\x10\xbc\xb6\xa4]\xb3"
+                       "\xd6\xed\xa9I\x8f\x890eJ\xf2e?\x8a\x93\x8c\xd8\x01")
+DOMAIN_HASHES = (DUMMYTRACKER_DOMAIN_HASH + EXAMPLE_DOMAIN_HASH
+                 + GOOGLE_DOMAIN_HASH)
 
 WRITE_SAFEBROWSING_BLOCKLIST_TESTCASES = (
     ("version", "78.0",
-        (3, 115, b"a:%d:32:96\n", (TEST_DOMAIN_HASH
-                                   + VERSIONED_TEST_DOMAIN_HASH
-                                   + DUMMYTRACKER_DOMAIN_HASH))),
+        (5, 180, b"a:%d:32:160\n", (TEST_DOMAIN_HASH
+                                    + VERSIONED_TEST_DOMAIN_HASH
+                                    + DOMAIN_HASHES))),
     ("no_version", None,
-        (2, 83, b"a:%d:32:64\n", (TEST_DOMAIN_HASH
-                                  + DUMMYTRACKER_DOMAIN_HASH))),
+        (4, 148, b"a:%d:32:128\n", (TEST_DOMAIN_HASH
+                                    + DOMAIN_HASHES))),
     ("no_test_domains", "78.0",
-        (1, 51, b"a:%d:32:32\n", DUMMYTRACKER_DOMAIN_HASH)),
+        (3, 115, b"a:%d:32:96\n", DOMAIN_HASHES)),
 )
 
 TEST_ENTITY_DICT = {
@@ -191,8 +197,7 @@ PROCESS_PLUGIN_BLOCKLIST_EXPECTED_OUTPUT_WRITES = (
     b"a:%d:32:64\n",
     (
         DUMMYTRACKER_DOMAIN_HASH,
-        (b"\xbc\x9a\x8f+o\xff\xd5\x85q\xe1\x88\xbb\x11\x05E\xf8\xfb:"
-         "\xf5\x1c\xdf\x1acimPZ\x98p\xa8[\xe5"),
+        GOOGLE_DOMAIN_HASH,
     ),
 )
 
@@ -206,19 +211,19 @@ PROCESS_PLUGIN_BLOCKLIST_EXPECTED_LOG_WRITE_INFO = (
 GET_TRACKER_LISTS_TESTCASES = (
     (
         "default", "tracking-protection",
-        {"adnetwork.net", "appcast.io", "clickguard.com",
-         "google-analytics.com", "postrank.com", "twimg.com",
-         "twitter.com", "twitter.jp"}
+        {"adnetwork.net/", "appcast.io/", "clickguard.com/",
+         "google-analytics.com/", "postrank.com/", "twimg.com/",
+         "twitter.com/", "twitter.jp/"}
     ),
     (
         "categories", "tracking-protection-base-fingerprinting",
-        {"appcast.io", "clickguard.com"}
+        {"appcast.io/", "clickguard.com/"}
     ),
     (
         "excluded_categories", "tracking-protection-content-fingerprinting",
         {"base-fingerprinting-track-digest256.dummytracker.org/tracker.js"}
     ),
-    ("tags", "tracking-protection-base-cryptomining", {"coinpot.co"}),
+    ("tags", "tracking-protection-base-cryptomining", {"coinpot.co/"}),
     ("invalid_tag", "tracking-protection-ads", set()),
     ("version", "tracking-protection-content-cryptomining", set()),
 )
@@ -351,26 +356,28 @@ def test_canonicalize(url, expected):
     assert l2s.canonicalize(url) == expected
 
 
-def _add_domain_to_list(domain, previous_domains, output):
+def _add_domain_to_list(domain, canonicalized_domain, previous_domain,
+                        output):
     """Auxiliary function for add_domain_to_list tests."""
-    canonicalized_domain = l2s.canonicalize(domain)
     domain_hash = hashlib.sha256(canonicalized_domain.encode("utf-8"))
 
     with patch("test_lists2safebrowsing.open", mock_open()):
         with open("test_blocklist.log", "w") as log_file:
-            added = l2s.add_domain_to_list(domain, previous_domains,
-                                           log_file, output)
+            added = l2s.add_domain_to_list(domain, canonicalized_domain,
+                                           previous_domain, log_file,
+                                           output)
             log_writes = log_file.write.call_args_list
 
-    return (added, canonicalized_domain, domain_hash, previous_domains,
-            log_writes, output)
+    return added, domain_hash, log_writes, output
 
 
 def test_add_domain_to_list():
     """Test adding a domain to a blocklist."""
     domain = "https://www.host.com"
-    (added, canonicalized_domain, domain_hash, previous_domains,
-     log_writes, output) = _add_domain_to_list(domain, set(), [])
+    canonicalized_domain = "www.host.com"
+    added, domain_hash, log_writes, output = (
+        _add_domain_to_list(domain, canonicalized_domain, None, [])
+    )
 
     expected_log_writes = [
         call("[m] %s >> %s\n" % (domain, canonicalized_domain)),
@@ -379,7 +386,6 @@ def test_add_domain_to_list():
     ]
 
     assert added
-    assert canonicalized_domain in previous_domains
     assert domain_hash.digest() in output
     assert log_writes == expected_log_writes
 
@@ -390,7 +396,7 @@ def test_add_domain_to_list_psl_public():
     add_domain_to_list raises a ValueError
     """
     with pytest.raises(ValueError):
-        _add_domain_to_list("https://co.uk", set(), [])
+        _add_domain_to_list("https://co.uk", "co.uk/", None, [])
 
 
 def test_add_domain_to_list_psl_private():
@@ -398,21 +404,23 @@ def test_add_domain_to_list_psl_private():
 
     add_domain_to_list adds them to the blocklist
     """
-    assert _add_domain_to_list("https://apps.fbsbx.com", set(), [])[0]
+    assert _add_domain_to_list("https://apps.fbsbx.com",
+                               "apps.fbsbx.com/", None, [])[0]
 
 
 def test_add_domain_to_list_duplicate():
     """Test that add_domain_to_list does not add domains twice."""
     domain = "https://duplicate.com"
-    (added, canonicalized_domain, domain_hash, previous_domains, _,
-     output) = _add_domain_to_list(domain, set(), [])
+    canonicalized_domain = "duplicate.com/"
+    added, domain_hash, _, output = (
+        _add_domain_to_list(domain, canonicalized_domain, None, [])
+    )
 
     assert added
-    assert canonicalized_domain in previous_domains
     assert domain_hash.digest() in output
 
-    added, _, _, _, log_writes, output = _add_domain_to_list(
-        domain, previous_domains, output)
+    added, _, log_writes, output = _add_domain_to_list(
+        domain, canonicalized_domain, canonicalized_domain, output)
 
     assert not added
     assert output == [domain_hash.digest()]
@@ -507,16 +515,17 @@ def test_get_domains_from_filters_tags(capsys, parser):
 
 def _write_safebrowsing_blocklist(chunknum, version, write_to_file=True):
     """Auxiliary function for write_safebrowsing_blocklist tests."""
-    domain = CANONICALIZE_TESTCASES[0]
+    # Include the dummytracker domain twice in the input set to make
+    # sure it is only added to the blocklist once
+    domains = {CANONICALIZE_TESTCASES[0][1], "https://www.google.com",
+               "example.com/", CANONICALIZE_TESTCASES[0][2]}
     output_name = "test-track-digest256"
 
     with patch("test_lists2safebrowsing.open", mock_open()):
         with open(output_name, "wb") as output_file:
             output_file = output_file if write_to_file else None
-            # Include the domain twice in the input set to make sure it
-            # is only added to the blocklist once
             l2s.write_safebrowsing_blocklist(
-                {domain[1], domain[2]}, output_name, None, chunknum,
+                domains, output_name, None, chunknum,
                 output_file, TEST_SECTION, version)
 
     return output_file.write.call_args_list if write_to_file else []
@@ -556,6 +565,7 @@ def test_write_safebrowsing_blocklist(capsys, chunknum, testcase,
     expected_print = PRINT_MSG % ("Tracking protection", TEST_SECTION,
                                   domains_number, file_size)
 
+    # Ensure hashes are written in correct order and without duplicates
     assert output_writes == [call(expected_output)]
     assert capsys.readouterr().out == expected_print
 
@@ -565,7 +575,7 @@ def test_write_safebrowsing_blocklist_no_output_file(capsys, chunknum):
     _write_safebrowsing_blocklist(chunknum, "78.0", False)
 
     expected_print = PRINT_MSG % ("Tracking protection", TEST_SECTION,
-                                  3, 115)
+                                  5, 180)
 
     assert capsys.readouterr().out == expected_print
 
@@ -744,7 +754,7 @@ def test_get_tracker_lists(config, parser, chunknum, section, domains,
     if version:
         test_domains.append("%s-%s" % (version.replace(".", "-"),
                                        test_domains[0]))
-    expected_domains = test_domains + [l2s.canonicalize(d) for d in domains]
+    expected_domains = test_domains + sorted(domains)
     expected_hashes = [hashlib.sha256(d.encode("utf-8")).digest()
                        for d in expected_domains]
     expected_bytes = hashlib.sha256().digest_size * len(expected_hashes)

--- a/tests/test_lists2safebrowsing.py
+++ b/tests/test_lists2safebrowsing.py
@@ -158,7 +158,7 @@ TEST_ENTITY_DICT = {
         "resources": ["gmail.com", "google-analytics.com"]
       },
       "Twitter": {
-        "properties": ["twitter.com"],
+        "properties": ["twitter.com", "twitter.com"],
         "resources": ["twimg.com", "twitter.com"]
       },
     }


### PR DESCRIPTION
This PR makes sure we sort the domains before writing their hashes to the safebrowsing list files. This way, we ensure that any changes in the order of domains in the input lists will not trigger unnecessary list updates.

Additionally, this is a prerequisite for porting the list creation script to Python 3. [Hash randomization is enabled by default starting from Python 3.3](https://docs.python.org/3/whatsnew/3.3.html#builtin-functions-and-types) and this would result in a differently ordered list being created every time the script is run.

Addresses #132.

Notes:
 * The dummytracker domains are exempt from ordering and remain at the top of the lists
 * In the case of entity lists, URLs are primarily sorted based on the entity name and there is a secondary alphanumeric ordering within each entity
