### PR TITLE
Separate test requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           command: |
             virtualenv ~/venv
             source ~/venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements-test.txt
             pip install coverage-badge
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+pytest==6.1.1
+pytest-cov==2.10.1
+moto==1.3.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,3 @@ publicsuffixlist==0.7.5
 requests==2.24.0
 trackingprotection-tools==0.6.1
 packaging==20.4
-
-# test requirements
-pytest==6.1.1
-pytest-cov==2.10.1
-moto==1.3.16


### PR DESCRIPTION
# About this PR
Separating the test requirements prevents the Jenkins job from installing packages that won't be used.