### PR TITLE
Make GitHub API return all branches

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -41,7 +41,7 @@ psl = PublicSuffixList(only_icann=True)
 
 GITHUB_API_URL = 'https://api.github.com'
 SHAVAR_PROD_LISTS_BRANCHES_PATH = (
-    '/repos/mozilla-services/shavar-prod-lists/branches'
+    '/repos/mozilla-services/shavar-prod-lists/branches?per_page=100'
 )
 
 


### PR DESCRIPTION
# About this PR
GitHub API returns 30 results per page as defined [here](https://docs.github.com/en/rest/branches/branches). As a result, the script was only generating versioned shavar lists up until 99.0 (instead of 102.0). To fix this bug, we should grab all branches so the script creates versioned lists for all branches and not the first 30 is the GitHub API defaults to.