### PR TITLE
Add email category for trackers

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -56,6 +56,10 @@ DNT_SECTIONS = (
     "tracking-protection-email-content",
     "tracking-protection-email-base",
 )
+DNT_EMAIL_SECTIONS = (
+    "tracking-protection-email-content",
+    "tracking-protection-email-base",
+)
 DNT_CONTENT_SECTIONS = (
     "tracking-protection-content",
     "tracking-protection-contenteff",

--- a/constants.py
+++ b/constants.py
@@ -51,7 +51,10 @@ DNT_SECTIONS = (
     "tracking-protection-content-fingerprinting",
     "tracking-protection-base-cryptomining",
     "tracking-protection-content-cryptomining",
-    "tracking-protection-test-multitag"
+    "tracking-protection-test-multitag",
+    # email trackers added in 2022
+    "tracking-protection-email-content",
+    "tracking-protection-email-base",
 )
 DNT_CONTENT_SECTIONS = (
     "tracking-protection-content",
@@ -97,3 +100,4 @@ LARGE_ENTITIES = [
 ]
 
 VERS_LARGE_ENTITIES_SEPARATION_STARTED = 74
+VERSION_EMAIL_CATEGORY_INTRODUCED = 97

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -29,6 +29,7 @@ from constants import (
     LARGE_ENTITIES_SECTIONS,
     STANDARD_ENTITY_SECTION,
     TEST_DOMAIN_TEMPLATE,
+    VERSION_EMAIL_CATEGORY_INTRODUCED,
     VERS_LARGE_ENTITIES_SEPARATION_STARTED,
     ENTITYLIST_SECTIONS,
 )
@@ -614,12 +615,14 @@ def get_versioned_lists(config, chunknum, version):
             ver=version, output=config.get(section, 'output'))
         )
         version_configurations(config, section, version)
+        ver = p_version.parse(version)
         if (section in PRE_DNT_SECTIONS or section in DNT_SECTIONS):
+            if ver.release[0] < VERSION_EMAIL_CATEGORY_INTRODUCED:
+                continue
             output_file, log_file = get_tracker_lists(
                 config, section, chunknum)
 
         if section in ENTITYLIST_SECTIONS:
-            ver = p_version.parse(version)
             skip_large_entity_separation = (
                 ver.release[0] < VERS_LARGE_ENTITIES_SEPARATION_STARTED
                 and section in LARGE_ENTITIES_SECTIONS

--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -22,6 +22,7 @@ from constants import (
     DEFAULT_DISCONNECT_LIST_CATEGORIES,
     DEFAULT_DISCONNECT_LIST_TAGS,
     DNT_EFF_SECTIONS,
+    DNT_EMAIL_SECTIONS,
     DNT_SECTIONS,
     DNT_W3C_SECTIONS,
     PLUGIN_SECTIONS,
@@ -617,7 +618,12 @@ def get_versioned_lists(config, chunknum, version):
         version_configurations(config, section, version)
         ver = p_version.parse(version)
         if (section in PRE_DNT_SECTIONS or section in DNT_SECTIONS):
-            if ver.release[0] < VERSION_EMAIL_CATEGORY_INTRODUCED:
+            skip_section = (
+                section in DNT_EMAIL_SECTIONS
+                and ver.release[0] < VERSION_EMAIL_CATEGORY_INTRODUCED
+            )
+            if skip_section:
+                # import ipdb; ipdb.set_trace()
                 continue
             output_file, log_file = get_tracker_lists(
                 config, section, chunknum)


### PR DESCRIPTION
# About this PR
Email tracker category was introduced in https://github.com/mozilla-services/shavar-prod-lists/pull/586. This PR updates the list creation script to generate email tracker lists as well. 

# Acceptance Criteria
- [ ] Ignore versioned list for email trackers that are older than version 97
- [ ] For shavar-prod-list newer than version97, the script should create `base-email-track-digest256` and `content-email-track-digest256` which uses `Email` and `EmailStrict` category respectively.