### PR TITLE
Enable RS upload for the latest ETP list only, to serve to Nightly

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -692,6 +692,9 @@ def main():
 
     publish_to_cloud(config, chunknum)
 
+    # disable remote-settings upload for versioned lists
+    config.set('main', 'remote_settings_upload', 'False')
+
     # create and publish versioned lists
     resp = requests.get(GITHUB_API_URL + SHAVAR_PROD_LISTS_BRANCHES_PATH)
     if resp:


### PR DESCRIPTION
## Description
We intend to enable RS uploads for Nightly only in fx128 [Bug 1899359 - Flip pref in url-classifier to fetch ETP lists from Remote Settings in Nightly only](https://bugzilla.mozilla.org/show_bug.cgi?id=1899359)

## What this change will do

This PR enables RS uploads for unversioned lists, which is the latest version of the disconnect list.