### PR TITLE
Switch to kinto-http for Remote Settings requests

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -110,7 +110,7 @@ def get_record_remote_settings(id):
 
 def put_new_record_remote_settings(config, section, data):
     try:
-        rec_resp = client.create_record(id=data['id'],
+        rec_resp = client.update_record(id=data['id'],
             data=data)
 
         if not rec_resp:

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -27,7 +27,8 @@ from packaging import version as p_version
 from settings import (
     config as CONFIG,
     rs_auth_method,
-    BearerAuth
+    BearerAuth,
+    environment
 )
 
 from kinto_http import Client, BearerTokenAuth, KintoException
@@ -360,19 +361,19 @@ def request_rs_review():
             collection_name=REMOTE_SETTINGS_COLLECTION)
 
     # Check if we need to send in a request for review
-    rs_collection = requests.get(rs_collection_url, auth=REMOTE_SETTINGS_AUTH, timeout=10)
+    rs_collection = client.get_collection();
 
     if rs_collection:
         # If any data was published, we want to request review for it
         # status can be one of "work-in-progress", "to-sign" (approve), "to-review" (request review)
-        if rs_collection.json()['data']['status'] == "work-in-progress":
+        if rs_collection['data']['status'] == "work-in-progress":
             if environment == "dev":
                 print("\n*** Dev server does not require a review, approving changes ***\n")
                 # review not enabled in dev, approve changes
-                requests.patch(rs_collection_url, json={"data": {"status": "to-sign"}}, auth=REMOTE_SETTINGS_AUTH)
+                client.patch_collection(data={"status": "to-sign"});
             else:
                 print("\n*** Requesting review for updated/created records ***\n")
-                requests.patch(rs_collection_url, json={"data": {"status": "to-review"}}, auth=REMOTE_SETTINGS_AUTH)
+                client.patch_collection(data={"status": "to-review"});
         else:
             print("\n*** No changes were made, no new review request is needed ***\n")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ publicsuffixlist==0.7.5
 requests==2.32.0
 trackingprotection-tools==0.6.1
 packaging==20.4
+kinto-http==11.1.0


### PR DESCRIPTION
## Description

This PR deals with switching from using requests to kinto-http to communicate with the remote settings server.

## What this PR changes

- Add kinto_http as a new installation in requirements.txt
- switch from using requests to using a kinto-http client for operations like `get_record` `create_record`


## Tracking Bugs

- [ ] #184 

## Dependencies

### Blocks
- [ ] #194 
