### PR TITLE
Add automated review requests for updating/creating records

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -35,7 +35,8 @@ from constants import (
     ENTITYLIST_SECTIONS,
 )
 from publish2cloud import (
-    publish_to_cloud
+    publish_to_cloud,
+    request_rs_review
 )
 
 from settings import config
@@ -699,6 +700,11 @@ def main():
     else:
         print('\n\n*** Unable to get branches from shavar-prod-lists repo ***')
 
+    # We have to request review after all versions of the lists are done uploading
+    # to avoid multiple requests
+    # This function is only needed for remote settings uploads, the function checks the
+    # value of "remote_settings_upload" in the config file
+    request_rs_review()
 
 if __name__ == "__main__":
     main()

--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -28,6 +28,7 @@ from settings import (
     BearerAuth
 )
 
+
 try:
     REMOTE_SETTINGS_URL = ''
     if os.environ.get('SHAVAR_REMOTE_SETTINGS_URL', None):
@@ -36,8 +37,9 @@ try:
     REMOTE_SETTINGS_COLLECTION = CONFIG.get(
         'main', 'remote_settings_collection'
     )
-    REMOTE_SETTINGS_RECORD_PATH = ('/buckets/{bucket_name}'
-                                   + '/collections/{collection_name}/records')
+    REMOTE_SETTINGS_PATH = ('/buckets/{bucket_name}'
+                                   + '/collections/{collection_name}')
+
     REMOTE_SETTINGS_AUTH = ''
     if rs_auth_method == "token":
         if os.environ.get('SHAVAR_REMOTE_SETTINGS_TOKEN', None):
@@ -61,12 +63,12 @@ try:
 
     CLOUDFRONT_USER_ID = os.environ.get('CLOUDFRONT_USER_ID', None)
 
-except configparser.NoOptionError as err:
+except NoOptionError as err:
     REMOTE_SETTINGS_URL = ''
     REMOTE_SETTINGS_AUTH = None
     REMOTE_SETTINGS_BUCKET = ''
     REMOTE_SETTINGS_COLLECTION = ''
-    REMOTE_SETTINGS_RECORD_PATH = ''
+    REMOTE_SETTINGS_PATH = ''
     CLOUDFRONT_USER_ID = None
 
 
@@ -82,11 +84,11 @@ def chunk_metadata(fp):
 def make_record_url_remote_settings(id):
     remote_settings_record_url = (
         REMOTE_SETTINGS_URL
-        + REMOTE_SETTINGS_RECORD_PATH.format(
+        + REMOTE_SETTINGS_PATH.format(
             bucket_name=REMOTE_SETTINGS_BUCKET,
             collection_name=REMOTE_SETTINGS_COLLECTION)
     )
-    return remote_settings_record_url + '/{record_id}'.format(record_id=id)
+    return remote_settings_record_url + '/records/{record_id}'.format(record_id=id)
 
 
 def get_record_remote_settings(id):
@@ -132,7 +134,7 @@ def new_data_to_publish_to_remote_settings(config, section, new):
     remote_settings_config_exists = (REMOTE_SETTINGS_URL
                                      and REMOTE_SETTINGS_BUCKET
                                      and REMOTE_SETTINGS_COLLECTION
-                                     and REMOTE_SETTINGS_RECORD_PATH
+                                     and REMOTE_SETTINGS_PATH
                                      and REMOTE_SETTINGS_AUTH)
     if not remote_settings_config_exists:
         print('Missing config(s) for Remote Settings')
@@ -333,3 +335,35 @@ def publish_to_cloud(config, chunknum, check_versioning=None):
             publish_to_remote_settings(config, section, chunknum)
         else:
             print('Skipping Remote Settings upload for %s' % section)
+
+
+def request_rs_review():
+    if check_upload_config(
+            CONFIG, 'main', 'remote_settings_upload'
+        ) == False:
+        print("\n*** Remote Settings upload is not enabled for this run, no reviews are required ***\n")
+        return
+
+    rs_collection_url = REMOTE_SETTINGS_URL + \
+         REMOTE_SETTINGS_PATH.format(
+            bucket_name=REMOTE_SETTINGS_BUCKET,
+            collection_name=REMOTE_SETTINGS_COLLECTION)
+
+    # Check if we need to send in a request for review
+    rs_collection = requests.get(rs_collection_url, auth=REMOTE_SETTINGS_AUTH, timeout=10)
+
+    if rs_collection:
+        # If any data was published, we want to request review for it
+        # status can be one of "work-in-progress", "to-sign" (approve), "to-review" (request review)
+        if rs_collection.json()['data']['status'] == "work-in-progress":
+            if environment == "dev":
+                print("\n*** Dev server does not require a review, approving changes ***\n")
+                # review not enabled in dev, approve changes
+                requests.patch(rs_collection_url, json={"data": {"status": "to-sign"}}, auth=REMOTE_SETTINGS_AUTH)
+            else:
+                print("\n*** Requesting review for updated/created records ***\n")
+                requests.patch(rs_collection_url, json={"data": {"status": "to-review"}}, auth=REMOTE_SETTINGS_AUTH)
+        else:
+            print("\n*** No changes were made, no new review request is needed ***\n")
+    else:
+        print("\n*** Error while fetching collection status ***\n")

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,16 @@
-from configparser import ConfigParser
+from configparser import ConfigParser, NoOptionError
 import sys
 import os
 from requests import auth
+
+# Class to handle Bearer Token Authentication
+class BearerAuth(auth.AuthBase):
+    def __init__(self, token):
+        self.token = token
+    def __call__(self, r):
+        r.headers["Authorization"] = self.token
+        return r
+
 
 # For local testing purposes, make sure to set RS_TESTING_ENVIRONMENT to True,
 # ENVIRONMENT to "dev", and EXECUTION_ENVIRONMENT to "GKE"
@@ -15,7 +24,7 @@ ini_file = "shavar_list_creation.ini"
 
 # For local testing and GKE environments we want to use the rs_*.ini file
 if execution_environment != "JENKINS":
-    environment = os.getenv("ENVIRONMENT", "stage")
+    environment = os.getenv("ENVIRONMENT", "dev")
     ini_file = f"rs_{environment}.ini"
 
 filenames = config.read(ini_file)
@@ -23,11 +32,3 @@ filenames = config.read(ini_file)
 if not filenames:
     print(f"Error reading .ini file!", file=sys.stderr)
     sys.exit(-1)
-
-# Class to handle Bearer Token Authentication
-class BearerAuth(auth.AuthBase):
-    def __init__(self, token):
-        self.token = token
-    def __call__(self, r):
-        r.headers["Authorization"] = self.token
-        return r


### PR DESCRIPTION
### Warning

This patch depends on #192 merging first. It is easier to review this by commit to avoid looking at code from #192 as well while reviewing

## Description

We currently have to manually request a review for updated/new records in remote settings. This patch handles automating that process.

## What this patch covers

- [x] Switches `REMOTE_SETTINGS_RECORD_PATH` to `REMOTE_SETTINGS_PATH` to be able to easily access other requests with one variable
- [x] Checks the server if the collection has a status of `work-in-progress` and if so, requests a review
- [x] Enables automatic approval for dev server
- [x] Moves various variable initialization steps to `settings.py`

## Testing

- [x] Tried uploading to RS dev server and verified automatic approval
- [x] uploading to RS stage server and verifying email approval request