### PR TITLE
Align environment variable names to requirements for automation on GKE

### DIFF
--- a/rs_dev.ini
+++ b/rs_dev.ini
@@ -10,12 +10,9 @@ remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
 remote_settings_bucket=main-workspace
 # The remote settings collection that has the record of each safebrowsing formatted list
 remote_settings_collection=tracking-protection-lists
-# Auth info required if remote_settings_upload is true
-remote_settings_username=%(SHAVAR_REMOTE_SETTINGS_USERNAME)s
-remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
-
-# Token auth
-remote_settings_token=%(SHAVAR_REMOTE_SETTINGS_TOKEN)s
+# Credentials for building the Authorization Header
+# (eg. "Bearer f8435u30596", or for basic auth "some-user:some-password")
+remote_settings_authorization=%(AUTHORIZATION)s
 
 # DNT="", all categories except content category
 [tracking-protection-base]

--- a/rs_prod.ini
+++ b/rs_prod.ini
@@ -5,17 +5,14 @@ s3_upload=false
 
 # Enable rs upload
 remote_settings_upload=true
-remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
+remote_settings_url=%(SERVER)s
 # The remote settings bucket that has the tracking-protection-lists collection
 remote_settings_bucket=main-workspace
 # The remote settings collection that has the record of each safebrowsing formatted list
 remote_settings_collection=tracking-protection-lists
-# Auth info required if remote_settings_upload is true
-remote_settings_username=%(SHAVAR_REMOTE_SETTINGS_USERNAME)s
-remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
-
-# Token auth
-remote_settings_token=%(SHAVAR_REMOTE_SETTINGS_TOKEN)s
+# Credentials for building the Authorization Header
+# (eg. "Bearer f8435u30596", or for basic auth "some-user:some-password")
+remote_settings_authorization=%(AUTHORIZATION)s
 
 # DNT="", all categories except content category
 [tracking-protection-base]

--- a/rs_stage.ini
+++ b/rs_stage.ini
@@ -5,17 +5,14 @@ s3_upload=false
 
 # Enable rs upload
 remote_settings_upload=true
-remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
+remote_settings_url=%(SERVER)s
 # The remote settings bucket that has the tracking-protection-lists collection
 remote_settings_bucket=main-workspace
 # The remote settings collection that has the record of each safebrowsing formatted list
 remote_settings_collection=tracking-protection-lists
-# Auth info required if remote_settings_upload is true
-remote_settings_username=%(SHAVAR_REMOTE_SETTINGS_USERNAME)s
-remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
-
-# Token auth
-remote_settings_token=%(SHAVAR_REMOTE_SETTINGS_TOKEN)s
+# Credentials for building the Authorization Header
+# (eg. "Bearer f8435u30596", or for basic auth "some-user:some-password")
+remote_settings_authorization=%(AUTHORIZATION)s
 
 # DNT="", all categories except content category
 [tracking-protection-base]

--- a/sample_shavar_list_creation.ini
+++ b/sample_shavar_list_creation.ini
@@ -8,14 +8,14 @@ s3_bucket=mmc-shavar
 
 # DO NOT PUT REAL VALUES IN THIS FILE; PUT THEM IN ENVIRONMENT VARIABLES
 remote_settings_upload=false
-remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
+remote_settings_url=%(SERVER)s
 # The remote settings bucket that has the tracking-protection-lists collection
 remote_settings_bucket=main-workspace
 # The remote settings collection that has the record of each safebrowsing formatted list
 remote_settings_collection=tracking-protection-lists
-# Auth info required if remote_settings_upload is true
-remote_settings_username=%(SHAVAR_REMOTE_SETTINGS_USERNAME)s
-remote_settings_password=%(SHAVAR_REMOTE_SETTINGS_PASSWORD)s
+# Credentials for building the Authorization Header
+# (eg. Bearer f8435u30596, Basic some-user:some-password)
+remote_settings_authorization=%(AUTHORIZATION)s
 
 [tracking-protection]
 # The location of the Disconnect list

--- a/settings.py
+++ b/settings.py
@@ -18,10 +18,10 @@ if execution_environment != "JENKINS":
     environment = os.getenv("ENVIRONMENT", "stage")
     ini_file = f"rs_{environment}.ini"
 
-filenames = config.read(ini_file)
-
-if not filenames:
-    print(f"Error reading .ini file!", file=sys.stderr)
+try:
+    filenames = config.read(ini_file)
+except Exception as e:
+    print(f"Error reading .ini file: {e}!", file=sys.stderr)
     sys.exit(-1)
 
 # Class to handle Bearer Token Authentication


### PR DESCRIPTION
## Description

Aligns env variable names to what is specified [here](https://remote-settings.readthedocs.io/en/latest/support.html#how-do-i-automate-the-publication-of-records-forever). These are the items this patch covers:

- [x] Changes environment variable names from 
     - `SHAVAR_REMOTE_SETTINGS_URL` --> `SERVER`
     - `SHAVAR_REMOTE_SETTINGS_USERNAME`, `SHAVAR_REMOTE_SETTINGS_PASSWORD` --> `AUTHORIZATION`
- [x] Removes the previous method of authorization with two env variables for username and password
- [x] Adds new variable `remote_settings_authorization` to read new environment variable

## Tracking issues

- [ ] #196 