### PR TITLE
Fixed NoOptionError is not defined error

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -63,7 +63,7 @@ try:
 
     CLOUDFRONT_USER_ID = os.environ.get('CLOUDFRONT_USER_ID', None)
 
-except NoOptionError as err:
+except configparser.NoOptionError as err:
     REMOTE_SETTINGS_URL = ''
     REMOTE_SETTINGS_AUTH = None
     REMOTE_SETTINGS_BUCKET = ''


### PR DESCRIPTION
## Description

This error got slipped in a previous pr, where NoOptionError was not defined. This patch fixes that by accessing NoOptionError through `configparser`