### PR TITLE
Fix breakage in rs_dev.ini file caused by use of old environment variable

### DIFF
--- a/rs_dev.ini
+++ b/rs_dev.ini
@@ -5,7 +5,7 @@ s3_upload=false
 
 # Enable rs upload
 remote_settings_upload=true
-remote_settings_url=%(SHAVAR_REMOTE_SETTINGS_URL)s
+remote_settings_url=%(SERVER)s
 # The remote settings bucket that has the tracking-protection-lists collection
 remote_settings_bucket=main-workspace
 # The remote settings collection that has the record of each safebrowsing formatted list


### PR DESCRIPTION
## Description 

When creating the rs_dev.ini, I did not switch out `SHAVAR_REMOTE_SETTINGS_URL` for `SERVER`. This causes some discrepency for testing purposes and generally is not correct. This patch fixes this issue.