### PR TITLE
Switched to using kinto-http library

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -27,9 +27,11 @@ from packaging import version as p_version
 from settings import (
     config as CONFIG,
     rs_auth_method,
-    BearerAuth
+    BearerAuth,
+    environment
 )
 
+from kinto_http import Client, BearerTokenAuth, KintoException
 
 try:
     REMOTE_SETTINGS_URL = ''
@@ -62,6 +64,12 @@ except configparser.NoOptionError as err:
     REMOTE_SETTINGS_PATH = ''
     CLOUDFRONT_USER_ID = None
 
+client = Client(
+    server_url=REMOTE_SETTINGS_URL,
+    bucket=REMOTE_SETTINGS_BUCKET,
+    collection=REMOTE_SETTINGS_COLLECTION,
+    auth=REMOTE_SETTINGS_AUTH
+)
 
 def chunk_metadata(fp):
     header = fp.readline().decode().rstrip('\n')
@@ -84,25 +92,37 @@ def make_record_url_remote_settings(id):
 
 def get_record_remote_settings(id):
     record_url = make_record_url_remote_settings(id)
-    resp = requests.get(record_url, auth=REMOTE_SETTINGS_AUTH, timeout=10)
-    if not resp:
-        print('{0} looks like it hasn\'t been uploaded to '
-              'Remote Settings'.format(id))
+
+    try:
+        record = client.get_record(id=id)
+        print('{0} - Record exists in Remote Settings'
+            .format(id))
+
+        return record
+    except KintoException as e:
+        if e.response.status_code == 404 :
+            print('{0} -  Record does not exist in Remote Settings'
+            .format(id))
+        else:
+            print('{0} -  There was a problem getting record from '
+                    'Remote Settings: {1}'.format(id, e))
         return None
-    record = resp.json()['data']
-    return record
 
 
 def put_new_record_remote_settings(config, section, data):
+    try:
+        rec_resp = client.update_record(id=data['id'],
+            data=data)
+
+        if not rec_resp:
+            print('Failed to create/update record for %s. Error: %s' %
+                (data['Name'], rec_resp.content.decode()))
+            return rec_resp
+    except KintoException as e:
+        print('Failed to create/update record for {0}. Error: {1}'
+                .format(data['Name'], e))
+
     record_url = make_record_url_remote_settings(data['id'])
-    rec_resp = requests.put(
-        record_url, json={'data': data}, auth=REMOTE_SETTINGS_AUTH)
-
-    if not rec_resp:
-        print('Failed to create/update record for %s. Error: %s' %
-              (data['Name'], rec_resp.content.decode()))
-        return rec_resp
-
     attachment_url = record_url + '/attachment'
     files = [('attachment', open(config.get(section, 'output'), 'rb'))]
     att_resp = requests.post(
@@ -135,7 +155,7 @@ def new_data_to_publish_to_remote_settings(config, section, new):
     record = get_record_remote_settings(config.get(section, 'output'))
 
     rs_upload_needed = True
-    if record and record.get('Checksum') == new['checksum']:
+    if record and record.get('data')['Checksum'] == new['checksum']:
         rs_upload_needed = False
     return rs_upload_needed
 
@@ -341,19 +361,19 @@ def request_rs_review():
             collection_name=REMOTE_SETTINGS_COLLECTION)
 
     # Check if we need to send in a request for review
-    rs_collection = requests.get(rs_collection_url, auth=REMOTE_SETTINGS_AUTH, timeout=10)
+    rs_collection = client.get_collection();
 
     if rs_collection:
         # If any data was published, we want to request review for it
         # status can be one of "work-in-progress", "to-sign" (approve), "to-review" (request review)
-        if rs_collection.json()['data']['status'] == "work-in-progress":
+        if rs_collection['data']['status'] == "work-in-progress":
             if environment == "dev":
                 print("\n*** Dev server does not require a review, approving changes ***\n")
                 # review not enabled in dev, approve changes
-                requests.patch(rs_collection_url, json={"data": {"status": "to-sign"}}, auth=REMOTE_SETTINGS_AUTH)
+                client.patch_collection(data={"status": "to-sign"});
             else:
                 print("\n*** Requesting review for updated/created records ***\n")
-                requests.patch(rs_collection_url, json={"data": {"status": "to-review"}}, auth=REMOTE_SETTINGS_AUTH)
+                client.patch_collection(data={"status": "to-review"});
         else:
             print("\n*** No changes were made, no new review request is needed ***\n")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ publicsuffixlist==0.7.5
 requests==2.32.0
 trackingprotection-tools==0.6.1
 packaging==20.4
+kinto-http==11.1.0

--- a/settings.py
+++ b/settings.py
@@ -23,8 +23,8 @@ config = ConfigParser(os.environ)
 ini_file = "shavar_list_creation.ini"
 
 # For local testing and GKE environments we want to use the rs_*.ini file
+environment = os.getenv("ENVIRONMENT", "dev")
 if execution_environment != "JENKINS":
-    environment = os.getenv("ENVIRONMENT", "dev")
     ini_file = f"rs_{environment}.ini"
 
 try:


### PR DESCRIPTION
## Description

This PR deals with switching from using requests to kinto-http to communicate with the remote settings server.
What this PR changes
- Add kinto_http as a new installation in requirements.txt
- switch from using requests to using a kinto-http client for operations like get_record create_record

## Tracking Bugs

- [ ] #184

## Dependencies
### Blocks

- [ ] #194