### PR TITLE
Add check for remote settings enabled before setting supported versions

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -57,7 +57,6 @@ try:
         REMOTE_SETTINGS_AUTH = HTTPBasicAuth(*tuple(REMOTE_SETTINGS_AUTH.split(":", maxsplit=1)))
 
     CLOUDFRONT_USER_ID = os.environ.get('CLOUDFRONT_USER_ID', None)
-    NUMBER_OF_SUPPORTED_VERSIONS = CONFIG.get('main', 'num_supported_versions')
 
 except configparser.NoOptionError as err:
     REMOTE_SETTINGS_URL = ''
@@ -433,7 +432,7 @@ def deleteRecordFromRemoteSettings(list_id):
     except KintoException as e:
         error_info = e.response.json()
         if 'errno' in error_info and error_info['errno'] == 110:
-            print(f"{list_id} not found\n\n")
+            print(f"{list_id} not found\n")
         else:
             # Re-raise the exception if it's not errno 110
             raise

--- a/settings.py
+++ b/settings.py
@@ -41,6 +41,10 @@ class SharedVersionNumbers:
         self.oldest_supported_version = math.inf
 
     def updateSupportedVersions(self, prod_list_branches, config):
+        # make sure remote settings is enabled
+        if config.get('main', 'remote_settings_upload') == False:
+            return
+
         for branch in prod_list_branches:
             branch_name = branch.get('name')
             ver = p_version.parse(branch_name)


### PR DESCRIPTION
## Issue

I didn't add a check if remote_settings_upload is enabled or not, and this causes breakage on the shavar side. This PR fixes that problem.