### PR TITLE
Add a nightly test tracker domain

### DIFF
--- a/lists2safebrowsing.py
+++ b/lists2safebrowsing.py
@@ -307,14 +307,16 @@ def write_safebrowsing_blocklist(domains, output_name, log_file, chunk,
         num_test_domain_added += 1
         previous_domain = canonicalized_domain
 
+    test_domain_formatted = '{0}-{1}'.format("nightly", test_domain)
     if version:
-        test_domain = '{0}-{1}'.format(version.replace('.', '-'), test_domain)
-        canonicalized_domain = canonicalize(test_domain)
-        added = add_domain_to_list(test_domain, canonicalized_domain,
-                                   previous_domain, log_file, output)
-        if added:
-            num_test_domain_added += 1
-            previous_domain = canonicalized_domain
+        test_domain_formatted = '{0}-{1}'.format(version.replace('.', '-'), test_domain)
+
+    canonicalized_domain = canonicalize(test_domain_formatted)
+    added = add_domain_to_list(test_domain_formatted, canonicalized_domain,
+                                previous_domain, log_file, output)
+    if added:
+        num_test_domain_added += 1
+        previous_domain = canonicalized_domain
 
     if num_test_domain_added > 0:
         # TODO?: hashdata_bytes += hashdata.digest_size


### PR DESCRIPTION
## Description

This PR creates a new "nightly" test domain that is added for the master branch.

## Note
When testing on url-classifier, for the latest nightly, we use
`https://nightly-base-email-track-digest256.dummytracker.org`

For all other versions, we use
`https://version_num-0-base-email-track-digest256.dummytracker.org`

where version_num is the version of the firefox client (126, 125, 130 etc.)