### PR TITLE
Update the nightly record if the filter_expression has changed.

### DIFF
--- a/publish2cloud.py
+++ b/publish2cloud.py
@@ -170,6 +170,13 @@ def new_data_to_publish_to_remote_settings(config, section, new, version=None):
     # Check to see if update is needed on Remote Settings
     record = get_record_remote_settings(record_name)
 
+    if version is None:
+        # We need to check if the filter_expression needs to be updated for the
+        # nightly records. The filter_expression needs to be updated if the
+        # latest supported version has changed
+        if record.get('data')['filter_expression'] != f'env.version|versionCompare("{shared_state.latest_supported_version}.0a1") <= 0':
+            return True
+
     return not (record and record.get('data')['Checksum'] == new['checksum'])
 
 


### PR DESCRIPTION
Currently, we only update the nightly record if the safe browsing file checksum changes. However, we also need to update the nightly records when the filter_expression is changed, but the checksum doesn't change. This could happen when we increase the version number for the nightly records. 