### PR TITLE
[WebkitLists] P3. Add `publish2rs` script to push changes to RS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN python -m pip install --no-cache-dir -r requirements.txt
 # Copy the rest of the application code
 COPY --chown=app:app . .
 
-CMD ["python", "lists2safebrowsing.py"]
+CMD ["sh", "enrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+# Build and publish the tracking lists for safebrowsing and webkit
+python lists2safebrowsing.py
+python lists2webkit.py

--- a/lists2webkit.py
+++ b/lists2webkit.py
@@ -1,6 +1,7 @@
 import json
 import os
 from settings import config
+from publish2rs import publish2rs
 from constants import (
     DNT_SECTIONS,
     PRE_DNT_SECTIONS,
@@ -148,6 +149,15 @@ def main():
             generate_webkit_lists(domains, WEBKIT_BLOCK_COOKIES, ios_include_as, entities)
 
     print("All content blocker rules have been generated successfully.")
+
+    # Push to remote settings
+    try:
+        publish2rs()
+    except Exception as e:
+        print(f"Failed to push to RS. Make sure your environment variables are set correctly.")
+        return os.EX_CONFIG
+
+    return os.EX_OK
 
 if __name__ == "__main__":
     main()

--- a/lists2webkit.py
+++ b/lists2webkit.py
@@ -151,11 +151,7 @@ def main():
     print("All content blocker rules have been generated successfully.")
 
     # Push to remote settings
-    try:
-        publish2rs()
-    except Exception as e:
-        print(f"Failed to push to RS. Make sure your environment variables are set correctly.")
-        return os.EX_CONFIG
+    publish2rs()
 
     return os.EX_OK
 

--- a/publish2rs.py
+++ b/publish2rs.py
@@ -23,7 +23,7 @@ def get_file_hash(list_path):
         return hashlib.sha256(f.read()).hexdigest()
 
 SERVER = get_config_if_env("SERVER", "main", "remote_settings_url")
-BUCKET = config.get("main", "remote_settings_bucket")
+BUCKET = "main-workspace"
 COLLECTION = "tracking-protection-lists-ios"
 AUTHORIZATION = get_config_if_env("AUTHORIZATION", "main", "remote_settings_authorization")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "local").lower()
@@ -86,10 +86,10 @@ def publish2rs():
 
     if ENVIRONMENT == "dev":
         # Self approve changes on DEV.
-        client.patch_collection(data={"status": "to-sign"})
+        client.approve_changes(message="r+")
         print("Changes applied to dev server ✅")
     else:
         # Request review.
         print("Request review...", end="")
-        client.patch_collection(data={"status": "to-review"})
+        client.request_review(message="r?")
         print("✅")

--- a/publish2rs.py
+++ b/publish2rs.py
@@ -27,10 +27,15 @@ BUCKET = "main-workspace"
 COLLECTION = "tracking-protection-lists-ios"
 AUTHORIZATION = get_config_if_env("AUTHORIZATION", "main", "remote_settings_authorization")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "local").lower()
+DRY_RUN = os.getenv("DRY_RUN", "0") in "1yY"
 
 def publish2rs():
     client = kinto_http.Client(
-        server_url=SERVER, auth=AUTHORIZATION, bucket=BUCKET, collection=COLLECTION
+        server_url=SERVER,
+        auth=AUTHORIZATION,
+        bucket=BUCKET,
+        collection=COLLECTION,
+        dry_mode=DRY_RUN
     )
 
     remote_attachments = {

--- a/publish2rs.py
+++ b/publish2rs.py
@@ -62,6 +62,11 @@ def publish2rs():
     print(f"To update: {to_update}")
     print(f"To delete: {to_delete}")
 
+    has_pending_changes = (len(to_create) + len(to_update) + len(to_delete)) > 0
+    if not has_pending_changes:
+        print("Records are in sync. Nothing to do ✅.")
+        return os.EX_OK
+
     # Batch delete operations.
     # NOTE: Attachment deletion is implicit when deleting a record.
     with client.batch() as batch:

--- a/publish2rs.py
+++ b/publish2rs.py
@@ -15,8 +15,8 @@ def get_config_if_env(env_var, config_section, config_option, fallback=""):
     Return the config value if the environment variable exists; otherwise, return the fallback.
     """
     if env_var in os.environ:
-        return config.get(config_section, config_option, fallback=fallback)
-    return fallback
+        return os.environ[env_var]
+    return config.get(config_section, config_option, fallback=fallback)
 
 def get_file_hash(list_path):
     with open(list_path, "rb") as f:
@@ -53,7 +53,7 @@ def publish2rs():
             to_create.append({"name": name})
         elif remote_attachment["hash"] != hash:
             to_update.append({"id": remote_attachment["id"], "name": name})
-    # Remaining records in `remote_by_name_and_hash` are to be deleted.
+    # Remaining records in `remote_attachments` are to be deleted.
     to_delete = [{"id": record["id"]} for _, record in remote_attachments.items()]
 
     # Print changes
@@ -73,7 +73,7 @@ def publish2rs():
         for record in to_delete:
             batch.delete_record(id=record["id"])
 
-    # Adding, updating attachments on clien
+    # Adding, updating attachments on client
     # since batch operations are not supported.
     for record in to_create:
         id = str(uuid.uuid4())

--- a/publish2rs.py
+++ b/publish2rs.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import os
+import kinto_http
+import hashlib
+import pathlib
+import uuid
+
+from settings import config
+
+from constants import WEBKIT_LISTS_DIR
+
+def get_config_if_env(env_var, config_section, config_option, fallback=""):
+    """
+    Return the config value if the environment variable exists; otherwise, return the fallback.
+    """
+    if env_var in os.environ:
+        return config.get(config_section, config_option, fallback=fallback)
+    return fallback
+
+def get_file_hash(list_path):
+    with open(list_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+SERVER = get_config_if_env("SERVER", "main", "remote_settings_url")
+BUCKET = config.get("main", "remote_settings_bucket")
+COLLECTION = "tracking-protection-lists-ios"
+AUTHORIZATION = get_config_if_env("AUTHORIZATION", "main", "remote_settings_authorization")
+ENVIRONMENT = os.getenv("ENVIRONMENT", "local").lower()
+
+def publish2rs():
+    client = kinto_http.Client(
+        server_url=SERVER, auth=AUTHORIZATION, bucket=BUCKET, collection=COLLECTION
+    )
+
+    remote_attachments = {
+        r["name"]: {"id": r["id"], "hash": r["attachment"]["hash"]}
+        for r in client.get_records()
+    }
+
+    local_attachments = {
+        file.stem: get_file_hash(file)
+        for file in pathlib.Path(WEBKIT_LISTS_DIR).iterdir()
+    }
+
+    # Determine records to create, update, or delete
+    # by comparing the attachment sha256 hashes.
+    to_create = []
+    to_update = []
+    for name, hash in local_attachments.items():
+        remote_attachment = remote_attachments.pop(name, None)
+        if remote_attachment is None:
+            to_create.append({"name": name})
+        elif remote_attachment["hash"] != hash:
+            to_update.append({"id": remote_attachment["id"], "name": name})
+    # Remaining records in `remote_by_name_and_hash` are to be deleted.
+    to_delete = [{"id": record["id"]} for _, record in remote_attachments.items()]
+
+    # Print changes
+    print("Changes to apply:")
+    print(f"To create: {to_create}")
+    print(f"To update: {to_update}")
+    print(f"To delete: {to_delete}")
+
+    # Batch delete operations.
+    # NOTE: Attachment deletion is implicit when deleting a record.
+    with client.batch() as batch:
+        for record in to_delete:
+            batch.delete_record(id=record["id"])
+
+    # Adding, updating attachments on clien
+    # since batch operations are not supported.
+    for record in to_create:
+        id = str(uuid.uuid4())
+        filepath = f"{WEBKIT_LISTS_DIR}/{record['name']}.json"
+        client.add_attachment(id=id, data={"name": record["name"]}, filepath=filepath)
+    for record in to_update:
+        filepath = f"{WEBKIT_LISTS_DIR}/{record['name']}.json"
+        client.add_attachment(id=record["id"], filepath=filepath)
+
+
+    if ENVIRONMENT == "dev":
+        # Self approve changes on DEV.
+        client.patch_collection(data={"status": "to-sign"})
+        print("Changes applied to dev server ✅")
+    else:
+        # Request review.
+        print("Request review...", end="")
+        client.patch_collection(data={"status": "to-review"})
+        print("✅")

--- a/publish2rs.py
+++ b/publish2rs.py
@@ -91,7 +91,8 @@ def publish2rs():
 
     if ENVIRONMENT == "dev":
         # Self approve changes on DEV.
-        client.approve_changes(message="r+")
+        # message arg is not supported as of now.
+        client.approve_changes()
         print("Changes applied to dev server ✅")
     else:
         # Request review.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ publicsuffixlist==0.7.5
 requests==2.32.0
 trackingprotection-tools==0.6.1
 packaging==20.4
-kinto-http==11.6.0
+kinto-http==11.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ publicsuffixlist==0.7.5
 requests==2.32.0
 trackingprotection-tools==0.6.1
 packaging==20.4
-kinto-http==11.1.0
+kinto-http==11.6.0


### PR DESCRIPTION
## Description

This PR:
- Add publish2rs script that determines what to create, update and delete based on file digest.
- Add `entrypoint.sh` as an entrypoint to docker.
- Tracked in [FXIOS-10505](https://mozilla-hub.atlassian.net/browse/FXIOS-10505)
- Depends on #212


## Tested locally
I tested locally on the dev server adding, deleting and updating by:
- Adding `foo.json` to `webkit-lists/` and running `lists2webkit.py`
  - Result: foo record with attachment is created.
- Modifying `foo.json` and running `lists2webkit.py` again
  - Result: foo record is updated with new attachment.
- Deleting `foo.json` and running `lists2webkit.py` again
  - Result: foo record is deleted.
- Running `lists2webkit.py` on synced version.
  - Result: nothing is done and script exits successfully.
