### PR TITLE
FXIOS-16383 Fix deletion of non-Disconnect records

### DIFF
--- a/publish2rs.py
+++ b/publish2rs.py
@@ -58,8 +58,13 @@ def publish2rs():
             to_create.append({"name": name})
         elif remote_attachment["hash"] != hash:
             to_update.append({"id": remote_attachment["id"], "name": name})
-    # Remaining records in `remote_attachments` are to be deleted.
-    to_delete = [{"id": record["id"]} for _, record in remote_attachments.items()]
+    # Remaining records in `remote_attachments` are to be deleted but only records the
+    # pipeline manages (disconnect-prefixed).
+    to_delete = [
+        {"id": record["id"]}
+        for name, record in remote_attachments.items()
+        if name.startswith("disconnect-")
+    ]
 
     # Print changes
     print("Changes to apply:")


### PR DESCRIPTION
# About this PR

Fixes an issue with one of the scripts publishing our shavar/disconnect files to Remote Settings, which resulted in non-Disconnect records being automatically deleted incorrectly.

# Jira

Currently tracked in: https://mozilla-hub.atlassian.net/browse/FXIOS-16383

# Acceptance Criteria
- [ ] Verify that the `ad-block` record is no longer deleted when the nightly chronjob is run on backend

# Notes

Context and additional information: https://mozilla.slack.com/archives/C0559DDDPQF/p1784564144204479

/cc @issammani @artines1 @leplatrem 